### PR TITLE
Shape 좌표 속성 정리 및 Factory 패턴 개선

### DIFF
--- a/src/component/Shape.ts
+++ b/src/component/Shape.ts
@@ -43,16 +43,13 @@ export class Rectangle implements Shape {
   }
 }
 
-export class Circle implements Shape {
-  //TODO: ellipse로 수정
+export class Ellipse implements Shape {
   constructor(
     public id: number,
     public topLeftX: number,
     public topLeftY: number,
     public bottomRightX: number,
-    public bottomRightY: number, 
-    public radiusX: number,
-    public radiusY: number,
+    public bottomRightY: number,
     public color: string
   ) {}
 
@@ -62,6 +59,14 @@ export class Circle implements Shape {
 
   get centerY(): number {
     return (this.bottomRightY + this.topLeftY) / 2;
+  }
+
+  get radiusX(): number {
+    return Math.abs(this.bottomRightX - this.topLeftX) / 2;
+  }
+
+  get radiusY(): number {
+    return Math.abs(this.bottomRightY - this.topLeftY) / 2;
   }
 
   draw(ctx: CanvasRenderingContext2D) {

--- a/src/component/Shape.ts
+++ b/src/component/Shape.ts
@@ -1,5 +1,9 @@
 export interface Shape {
   id: number;
+  topLeftX: number,
+  topLeftY: number,
+  bottomRightX: number,
+  bottomRightY: number, 
   draw(ctx: CanvasRenderingContext2D | null): void;
   //TODO: move, resize 추가
   //move(dx: number, dy: number),
@@ -9,17 +13,33 @@ export interface Shape {
 export class Rectangle implements Shape {
   constructor(
     public id: number,
-    public x: number,
-    public y: number,
-    public width: number,
-    public height: number,
+    public topLeftX: number,
+    public topLeftY: number,
+    public bottomRightX: number,
+    public bottomRightY: number, 
     public color: string
   ) {}
+
+  get width(): number {
+    return this.bottomRightX - this.topLeftX;
+  }
+
+  get height(): number {
+    return this.bottomRightY - this.topLeftY;
+  }
+
+  get centerX(): number {
+    return (this.bottomRightX + this.topLeftX) / 2;
+  }
+
+  get centerY(): number {
+    return (this.bottomRightY + this.topLeftY) / 2;
+  }
 
   draw(ctx: CanvasRenderingContext2D) {
     if (!ctx) throw new Error("context is null");
     ctx.fillStyle = this.color;
-    ctx.fillRect(this.x, this.y, this.width, this.height);
+    ctx.fillRect(this.topLeftX, this.topLeftY, this.width, this.height);
   }
 }
 
@@ -27,16 +47,27 @@ export class Circle implements Shape {
   //TODO: ellipse로 수정
   constructor(
     public id: number,
-    public centerX: number,
-    public centerY: number,
-    public radius: number,
+    public topLeftX: number,
+    public topLeftY: number,
+    public bottomRightX: number,
+    public bottomRightY: number, 
+    public radiusX: number,
+    public radiusY: number,
     public color: string
   ) {}
+
+  get centerX(): number {
+    return (this.bottomRightX + this.topLeftX) / 2;
+  }
+
+  get centerY(): number {
+    return (this.bottomRightY + this.topLeftY) / 2;
+  }
 
   draw(ctx: CanvasRenderingContext2D) {
     ctx.fillStyle = this.color;
     ctx.beginPath();
-    ctx.arc(this.centerX, this.centerY, this.radius, 0, Math.PI * 2);
+    ctx.ellipse(this.centerX, this.centerY, this.radiusX, this.radiusY, 0, 0, Math.PI * 2);
     ctx.fill();
   }
 }

--- a/src/component/ShapeFactory.ts
+++ b/src/component/ShapeFactory.ts
@@ -9,19 +9,32 @@ interface ShapeProps {
   color: string;
 }
 
+interface ShapeCreator {
+  create(props: ShapeProps): Shape;
+}
+
+class RectangleCreator implements ShapeCreator {
+  create(props: ShapeProps): Shape {
+    return new Rectangle(props.id, props.startX, props.startY, props.endX, props.endY, props.color);
+  }
+}
+
+class EllipseCreator implements ShapeCreator {
+  create(props: ShapeProps): Shape {
+    return new Ellipse(props.id, props.startX, props.startY, props.endX, props.endY, props.color);
+  }
+}
+
 export class ShapeFactory {
+  private static creators: Record<string, ShapeCreator> = {
+    rectangle: new RectangleCreator(),
+    ellipse: new EllipseCreator(),
+  };
+
+
   static createShape(type: string, props: ShapeProps): Shape {
-    const { id, startX, startY, endX, endY, color } = props;
-
-    switch (type) {
-      case "rectangle":
-        return new Rectangle(id, startX, startY, endX, endY, color);
-
-      case "circle":
-        return new Ellipse(id, startX, startY, endX, endY, color);
-      
-      default:
-        throw new Error(`Unknown type shape ${type}`);
-    }
+    const creator = this.creators[type];
+    if (!creator) throw new Error(`Unknown type shape ${type}`);
+    return creator.create(props);
   }
 }

--- a/src/component/ShapeFactory.ts
+++ b/src/component/ShapeFactory.ts
@@ -1,22 +1,28 @@
 import { Circle, Rectangle, Shape } from "./Shape";
 
+interface ShapeProps {
+  id: number;
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  color: string;
+}
+
 export class ShapeFactory {
-  // TODO: props 타입 정의하기
-  // props가 startX, startY, endX, endY, color ... 속성을 가지고 있다고 전제
-  static createShape(type: string, props: any): Shape {
+  static createShape(type: string, props: ShapeProps): Shape {
+    const { id, startX, startY, endX, endY, color } = props;
+
     switch (type) {
       case "rectangle":
-        const x = props.startX;
-        const y = props.startY;
-        const width = props.endX - props.startX;
-        const height = props.endY - props.startY;
-        return new Rectangle(props.id, x, y, width, height, props.color);
+        return new Rectangle(id, startX, startY, endX, endY, color);
+
       case "circle":
-        //TODO: 이거 ellipse 못그리는거 같은데
-        const centerX = (props.startX + props.endX) / 2;
-        const centerY = (props.startY + props.endY) / 2;
-        const radius = Math.abs(props.endX - props.startX);
-        return new Circle(props.id, centerX, centerY, radius, props.color);
+        // 타원
+        const radiusX = Math.abs(endX - startX) / 2;
+        const radiusY = Math.abs(endY - startY) / 2;
+        return new Circle(id, startX, startY, endX, endY, radiusX, radiusY, color);
+      
       default:
         throw new Error(`Unknown type shape ${type}`);
     }

--- a/src/component/ShapeFactory.ts
+++ b/src/component/ShapeFactory.ts
@@ -1,4 +1,4 @@
-import { Circle, Rectangle, Shape } from "./Shape";
+import { Ellipse, Rectangle, Shape } from "./Shape";
 
 interface ShapeProps {
   id: number;
@@ -18,10 +18,7 @@ export class ShapeFactory {
         return new Rectangle(id, startX, startY, endX, endY, color);
 
       case "circle":
-        // 타원
-        const radiusX = Math.abs(endX - startX) / 2;
-        const radiusY = Math.abs(endY - startY) / 2;
-        return new Circle(id, startX, startY, endX, endY, radiusX, radiusY, color);
+        return new Ellipse(id, startX, startY, endX, endY, color);
       
       default:
         throw new Error(`Unknown type shape ${type}`);

--- a/src/view/ShapeButton.tsx
+++ b/src/view/ShapeButton.tsx
@@ -20,12 +20,12 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
       <div>
         <input
           type="radio"
-          id="circle"
+          id="ellipse"
           name="shapeType"
-          value="circle"
-          onChange={() => (viewModel.shapeType = "circle")}
+          value="ellipse"
+          onChange={() => (viewModel.shapeType = "ellipse")}
         />
-        <label>원</label>
+        <label>타원</label>
       </div>
     </fieldset>
   );

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -36,8 +36,11 @@ export class CanvasViewModel {
   };
 
   handleMouseMove = (event: React.MouseEvent) => {
-    if (!this.drawing) return;
+    if (!this.drawing || !this.canvas) return;
+
     const { offsetX, offsetY } = event.nativeEvent;
+    if (offsetX === this.endX && offsetY === this.endY) return; // 변화 없으면 무시
+
     this.endX = offsetX;
     this.endY = offsetY;
     this.redrawCanvas(); // 실시간 반영
@@ -63,9 +66,7 @@ export class CanvasViewModel {
     if (!this.ctx || !this.canvas) return;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height); // 캔버스 초기화
 
-    this.model.getShapes().forEach((shape) => {
-      shape.draw(this.ctx);
-    });
+    this.model.getShapes().forEach((shape) => shape.draw(this.ctx));
 
     if (this.drawing) {
       ShapeFactory.createShape(this.shapeType, {


### PR DESCRIPTION
## Shape 클래스 리팩토링

- Shape 좌표 속성 추가
- Circle을 Ellipse로 변경, radiusX, radiusY를 getter로 계산하도록 수정
- ShapeButton의 input value를 "circle" → "ellipse"로 수정

## ShapeFactory에 Strategy Pattern 적용

- switch-case 문을 제거하고, 각 Shape 클래스가 자체적으로 인스턴스를 생성하도록 변경함. 새로운 도형 추가 시 ShapeFactory를 수정할 필요 없이 확장 가능!

## 그외
- 캔버스 리렌더링 최적화(?)

## 이거 봐주세요 !!!
- Shape 좌표 용어 헷갈리면 startX/Y, endX/Y로 할까...?