### PR TITLE
선택 기능 추가

### DIFF
--- a/src/model/CanvasModel.ts
+++ b/src/model/CanvasModel.ts
@@ -2,6 +2,7 @@ import { Shape } from "../entity/Shape";
 
 export class CanvasModel {
   private shapes: Shape[] = [];
+  private selectedShapes: Shape[] = [];
 
   addShape(shape: Shape) {
     this.shapes.push(shape);
@@ -17,5 +18,17 @@ export class CanvasModel {
 
   countShapes(): number {
     return this.shapes.length;
+  }
+
+  clearSelectedShapes() {
+    this.selectedShapes = [];
+  }
+
+  addSelectedShapes(shape: Shape) {
+    this.selectedShapes.push(shape);
+  }
+
+  getSelectedShapes(): Shape[] {
+    return [...this.selectedShapes];
   }
 }

--- a/src/view/Canvas.tsx
+++ b/src/view/Canvas.tsx
@@ -5,11 +5,19 @@ import { Shape } from "../entity/Shape";
 const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [shapes, setShapes] = useState<Shape[]>(viewModel.getShapes());
+  const [selectedShapes, setSelectedShapes] = useState<Shape[]>(
+    viewModel.getSelectedShapes()
+  );
 
   //set observer
   useEffect(() => {
     const observer = {
-      update: (updatedShapes: Shape[]) => setShapes([...updatedShapes]),
+      update: (updatedShapes: Shape[][]) => {
+        const drawShapes = updatedShapes[0];
+        const selectedShape = updatedShapes[1];
+        setShapes([...drawShapes]);
+        setSelectedShapes([...selectedShape]);
+      },
     };
     viewModel.subscribe(observer);
 

--- a/src/view/ShapeButton.tsx
+++ b/src/view/ShapeButton.tsx
@@ -14,7 +14,7 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
           name="shapeType"
           value="rectangle"
           onChange={() => {
-            viewModel.shapeType = "rectangle";
+            viewModel.setShapeType("rectangle");
             viewModel.setState(new DrawingState(viewModel)); // 상태 변경
           }}
         />
@@ -28,7 +28,7 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
           name="shapeType"
           value="ellipse"
           onChange={() => {
-            viewModel.shapeType = "ellipse";
+            viewModel.setShapeType("ellipse");
             viewModel.setState(new DrawingState(viewModel)); // 상태 변경
           }}
         />
@@ -42,7 +42,7 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
           name="shapeType"
           value="select"
           onChange={() => {
-            viewModel.shapeType = "";
+            viewModel.setShapeType("select");
             viewModel.setState(new SelectState(viewModel)); // 상태 변경
           }}
         />

--- a/src/view/ShapeButton.tsx
+++ b/src/view/ShapeButton.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CanvasViewModel } from "../viewModel/CanvasViewModel";
+import { DrawingState, SelectState } from "../viewModel/CanvasState";
 
 const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
   viewModel,
@@ -12,7 +13,10 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
           id="rectangle"
           name="shapeType"
           value="rectangle"
-          onChange={() => (viewModel.shapeType = "rectangle")}
+          onChange={() => {
+            viewModel.shapeType = "rectangle";
+            viewModel.setState(new DrawingState(viewModel)); // 상태 변경
+          }}
         />
         <label>사각형</label>
       </div>
@@ -23,7 +27,10 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
           id="ellipse"
           name="shapeType"
           value="ellipse"
-          onChange={() => (viewModel.shapeType = "ellipse")}
+          onChange={() => {
+            viewModel.shapeType = "ellipse";
+            viewModel.setState(new DrawingState(viewModel)); // 상태 변경
+          }}
         />
         <label>원</label>
       </div>
@@ -34,7 +41,10 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
           id="select"
           name="shapeType"
           value="select"
-          onChange={() => (viewModel.shapeType = "select")}
+          onChange={() => {
+            viewModel.shapeType = "";
+            viewModel.setState(new SelectState(viewModel)); // 상태 변경
+          }}
         />
         <label>선택</label>
       </div>

--- a/src/view/ShapeButton.tsx
+++ b/src/view/ShapeButton.tsx
@@ -20,9 +20,20 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
       <div>
         <input
           type="radio"
+          id="circle"
+          name="shapeType"
+          value="circle"
+          onChange={() => (viewModel.shapeType = "circle")}
+        />
+        <label>원</label>
+      </div>
+
+      <div>
+        <input
+          type="radio"
           id="ellipse"
           name="shapeType"
-          value="ellipse"
+          value="select"
           onChange={() => (viewModel.shapeType = "ellipse")}
         />
         <label>타원</label>

--- a/src/view/ShapeButton.tsx
+++ b/src/view/ShapeButton.tsx
@@ -20,10 +20,10 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
       <div>
         <input
           type="radio"
-          id="circle"
+          id="ellipse"
           name="shapeType"
-          value="circle"
-          onChange={() => (viewModel.shapeType = "circle")}
+          value="ellipse"
+          onChange={() => (viewModel.shapeType = "ellipse")}
         />
         <label>원</label>
       </div>
@@ -31,12 +31,12 @@ const ShapeButton: React.FC<{ viewModel: CanvasViewModel }> = ({
       <div>
         <input
           type="radio"
-          id="ellipse"
+          id="select"
           name="shapeType"
           value="select"
-          onChange={() => (viewModel.shapeType = "ellipse")}
+          onChange={() => (viewModel.shapeType = "select")}
         />
-        <label>타원</label>
+        <label>선택</label>
       </div>
     </fieldset>
   );

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -1,5 +1,7 @@
 import React from "react";
 import { CanvasViewModel } from "./CanvasViewModel";
+import { ShapeFactory } from "../entity/ShapeFactory";
+import { Shape } from "../entity/Shape";
 
 export interface ICanvasState {
   handleMouseDown(event: React.MouseEvent): void;
@@ -7,22 +9,104 @@ export interface ICanvasState {
   handleMouseUp(event: React.MouseEvent): void;
 }
 
+//TODO: viewModel에 있던 구현을 옮겨옴. model 메소드 호출을 제거하고 viewModel을 통해서 model 참조하도록 수정하기
 export class DrawingState implements ICanvasState {
+  private startX = 0;
+  private startY = 0;
+  private endX = 0;
+  private endY = 0;
+  private color = "black";
+  private drawingShape: Shape | null = null;
+  private drawing = false;
   constructor(private viewModel: CanvasViewModel) {}
 
-  handleMouseDown(event: React.MouseEvent): void {}
+  handleMouseDown(event: React.MouseEvent): void {
+    const { offsetX, offsetY } = event.nativeEvent;
+    this.startX = offsetX;
+    this.startY = offsetY;
+    this.endX = offsetX;
+    this.endY = offsetY;
 
-  handleMouseMove(event: React.MouseEvent): void {}
+    this.drawing = true;
+  }
 
-  handleMouseUp(event: React.MouseEvent): void {}
+  handleMouseMove(event: React.MouseEvent): void {
+    const { offsetX, offsetY } = event.nativeEvent;
+    if (offsetX === this.endX && offsetY === this.endY) return; // 변화 없으면 무시
+    if (!this.drawing) return;
+
+    this.endX = offsetX;
+    this.endY = offsetY;
+
+    this.drawingShape = ShapeFactory.createShape(this.viewModel.shapeType, {
+      id: this.viewModel.getCountShapes(), //TODO: getCountShapes 추가
+      startX: this.startX,
+      startY: this.startY,
+      endX: this.endX,
+      endY: this.endY,
+      color: this.color,
+    });
+  }
+
+  handleMouseUp(event: React.MouseEvent): void {
+    if (!this.drawing) return;
+    this.drawing = false;
+    if (this.drawingShape) {
+      this.viewModel.addShape(this.drawingShape); //TODO: addShape 추가
+      this.drawingShape = null; // reset drawing shape
+    }
+  }
 }
 
 export class SelectState implements ICanvasState {
+  private startX = 0;
+  private startY = 0;
+  private endX = 0;
+  private endY = 0;
+  private selecting = false;
   constructor(private viewModel: CanvasViewModel) {}
 
-  handleMouseDown(event: React.MouseEvent): void {}
+  handleMouseDown(event: React.MouseEvent): void {
+    const { offsetX, offsetY } = event.nativeEvent;
+    this.startX = offsetX;
+    this.startY = offsetY;
+    this.endX = offsetX;
+    this.endY = offsetY;
 
-  handleMouseMove(event: React.MouseEvent): void {}
+    this.selecting = true; //TODO: 시작점이 도형 내부라면 바로 select, 아니라면 다중 select
+  }
+
+  handleMouseMove(event: React.MouseEvent): void {
+    const { offsetX, offsetY } = event.nativeEvent;
+    if (offsetX === this.endX && offsetY === this.endY) return; // 변화 없으면 무시
+    if (!this.selecting) return;
+
+    this.endX = offsetX;
+    this.endY = offsetY;
+
+    this.model.clearSelectedShapes(); //TODO: clearSelectedShapes 추가
+    this.selectShapes(this.startX, this.startY, this.endX, this.endY);
+  }
 
   handleMouseUp(event: React.MouseEvent): void {}
+
+  selectShapes(startX: number, startY: number, endX: number, endY: number) {
+    this.model.clearSelectedShapes();
+
+    const minX = Math.min(startX, endX);
+    const maxX = Math.max(startX, endX);
+    const minY = Math.min(startY, endY);
+    const maxY = Math.max(startY, endY);
+
+    this.viewModel.getShapes().forEach((shape) => {
+      if (
+        ((minX <= shape.startX && shape.startX <= maxX) ||
+          (minX <= shape.endX && shape.endX <= maxX)) &&
+        ((minY <= shape.startY && shape.startY <= maxY) ||
+          (minY <= shape.endY && shape.endY <= maxY))
+      ) {
+        this.model.addSelectedShapes(shape);
+      }
+    });
+  }
 }

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -38,14 +38,17 @@ export class DrawingState implements ICanvasState {
     this.endX = offsetX;
     this.endY = offsetY;
 
-    this.drawingShape = ShapeFactory.createShape(this.viewModel.shapeType, {
-      id: this.viewModel.countShapes(),
-      startX: this.startX,
-      startY: this.startY,
-      endX: this.endX,
-      endY: this.endY,
-      color: this.color,
-    });
+    this.drawingShape = ShapeFactory.createShape(
+      this.viewModel.getShapeType(),
+      {
+        id: this.viewModel.countShapes(),
+        startX: this.startX,
+        startY: this.startY,
+        endX: this.endX,
+        endY: this.endY,
+        color: this.color,
+      }
+    );
   }
 
   handleMouseUp(): void {

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -9,7 +9,6 @@ export interface ICanvasState {
   handleMouseUp(event: React.MouseEvent): void;
 }
 
-//TODO: viewModel에 있던 구현을 옮겨옴. model 메소드 호출을 제거하고 viewModel을 통해서 model 참조하도록 수정하기
 export class DrawingState implements ICanvasState {
   private startX = 0;
   private startY = 0;
@@ -39,7 +38,7 @@ export class DrawingState implements ICanvasState {
     this.endY = offsetY;
 
     this.drawingShape = ShapeFactory.createShape(this.viewModel.shapeType, {
-      id: this.viewModel.getCountShapes(), //TODO: getCountShapes 추가
+      id: this.viewModel.getCountShapes(),
       startX: this.startX,
       startY: this.startY,
       endX: this.endX,
@@ -52,7 +51,7 @@ export class DrawingState implements ICanvasState {
     if (!this.drawing) return;
     this.drawing = false;
     if (this.drawingShape) {
-      this.viewModel.addShape(this.drawingShape); //TODO: addShape 추가
+      this.viewModel.addShape(this.drawingShape);
       this.drawingShape = null; // reset drawing shape
     }
   }
@@ -84,14 +83,14 @@ export class SelectState implements ICanvasState {
     this.endX = offsetX;
     this.endY = offsetY;
 
-    this.model.clearSelectedShapes(); //TODO: clearSelectedShapes 추가
+    this.viewModel.clearSelectedShapes();
     this.selectShapes(this.startX, this.startY, this.endX, this.endY);
   }
 
   handleMouseUp(event: React.MouseEvent): void {}
 
   selectShapes(startX: number, startY: number, endX: number, endY: number) {
-    this.model.clearSelectedShapes();
+    this.viewModel.clearSelectedShapes();
 
     const minX = Math.min(startX, endX);
     const maxX = Math.max(startX, endX);
@@ -105,7 +104,7 @@ export class SelectState implements ICanvasState {
         ((minY <= shape.startY && shape.startY <= maxY) ||
           (minY <= shape.endY && shape.endY <= maxY))
       ) {
-        this.model.addSelectedShapes(shape);
+        this.viewModel.addSelectedShapes(shape);
       }
     });
   }

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -6,7 +6,8 @@ import { Shape } from "../entity/Shape";
 export interface ICanvasState {
   handleMouseDown(event: React.MouseEvent): void;
   handleMouseMove(event: React.MouseEvent): void;
-  handleMouseUp(event: React.MouseEvent): void;
+  handleMouseUp(): void;
+  getCurrentShapes(): Shape[];
 }
 
 export class DrawingState implements ICanvasState {
@@ -38,7 +39,7 @@ export class DrawingState implements ICanvasState {
     this.endY = offsetY;
 
     this.drawingShape = ShapeFactory.createShape(this.viewModel.shapeType, {
-      id: this.viewModel.getCountShapes(),
+      id: this.viewModel.countShapes(),
       startX: this.startX,
       startY: this.startY,
       endX: this.endX,
@@ -47,13 +48,22 @@ export class DrawingState implements ICanvasState {
     });
   }
 
-  handleMouseUp(event: React.MouseEvent): void {
+  handleMouseUp(): void {
     if (!this.drawing) return;
     this.drawing = false;
     if (this.drawingShape) {
       this.viewModel.addShape(this.drawingShape);
       this.drawingShape = null; // reset drawing shape
     }
+  }
+
+  getCurrentShapes(): Shape[] {
+    if (this.drawing) {
+      return this.drawingShape
+        ? [...this.viewModel.getSavedShapes(), this.drawingShape]
+        : this.viewModel.getSavedShapes();
+    }
+    return this.viewModel.getSavedShapes();
   }
 }
 
@@ -87,7 +97,7 @@ export class SelectState implements ICanvasState {
     this.selectShapes(this.startX, this.startY, this.endX, this.endY);
   }
 
-  handleMouseUp(event: React.MouseEvent): void {}
+  handleMouseUp(): void {}
 
   selectShapes(startX: number, startY: number, endX: number, endY: number) {
     this.viewModel.clearSelectedShapes();
@@ -97,7 +107,7 @@ export class SelectState implements ICanvasState {
     const minY = Math.min(startY, endY);
     const maxY = Math.max(startY, endY);
 
-    this.viewModel.getShapes().forEach((shape) => {
+    this.viewModel.getSavedShapes().forEach((shape) => {
       if (
         ((minX <= shape.startX && shape.startX <= maxX) ||
           (minX <= shape.endX && shape.endX <= maxX)) &&
@@ -107,5 +117,9 @@ export class SelectState implements ICanvasState {
         this.viewModel.addSelectedShapes(shape);
       }
     });
+  }
+
+  getCurrentShapes(): Shape[] {
+    return this.viewModel.getSavedShapes();
   }
 }

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -1,0 +1,28 @@
+import React from "react";
+import { CanvasViewModel } from "./CanvasViewModel";
+
+export interface ICanvasState {
+  handleMouseDown(event: React.MouseEvent): void;
+  handleMouseMove(event: React.MouseEvent): void;
+  handleMouseUp(event: React.MouseEvent): void;
+}
+
+export class DrawingState implements ICanvasState {
+  constructor(private viewModel: CanvasViewModel) {}
+
+  handleMouseDown(event: React.MouseEvent): void {}
+
+  handleMouseMove(event: React.MouseEvent): void {}
+
+  handleMouseUp(event: React.MouseEvent): void {}
+}
+
+export class SelectState implements ICanvasState {
+  constructor(private viewModel: CanvasViewModel) {}
+
+  handleMouseDown(event: React.MouseEvent): void {}
+
+  handleMouseMove(event: React.MouseEvent): void {}
+
+  handleMouseUp(event: React.MouseEvent): void {}
+}

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -97,7 +97,9 @@ export class SelectState implements ICanvasState {
     this.selectShapes(this.startX, this.startY, this.endX, this.endY);
   }
 
-  handleMouseUp(): void {}
+  handleMouseUp(): void {
+    console.log(this.viewModel.getSelectedShapes());
+  }
 
   selectShapes(startX: number, startY: number, endX: number, endY: number) {
     this.viewModel.clearSelectedShapes();
@@ -108,11 +110,14 @@ export class SelectState implements ICanvasState {
     const maxY = Math.max(startY, endY);
 
     this.viewModel.getSavedShapes().forEach((shape) => {
+      const shapeMinX = Math.min(shape.startX, shape.endX);
+      const shapeMaxX = Math.max(shape.startX, shape.endX);
+      const shapeMinY = Math.min(shape.startY, shape.endY);
+      const shapeMaxY = Math.max(shape.startY, shape.endY);
+
       if (
-        ((minX <= shape.startX && shape.startX <= maxX) ||
-          (minX <= shape.endX && shape.endX <= maxX)) &&
-        ((minY <= shape.startY && shape.startY <= maxY) ||
-          (minY <= shape.endY && shape.endY <= maxY))
+        !(shapeMaxX < minX || maxX < shapeMinX) &&
+        !(shapeMaxY < minY || maxY < shapeMinY)
       ) {
         this.viewModel.addSelectedShapes(shape);
       }

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -85,6 +85,8 @@ export class SelectState implements ICanvasState {
     this.endX = offsetX;
     this.endY = offsetY;
 
+    this.viewModel.clearSelectedShapes();
+
     this.selecting = true; //TODO: 시작점이 도형 내부라면 바로 select, 아니라면 다중 select
   }
 

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -38,6 +38,7 @@ export class CanvasViewModel extends Observable {
     this.endY = offsetY;
 
     if (this.shapeType !== "select") this.drawing = true;
+    this.model.clearSelectedShapes();
   };
 
   handleMouseMove = (event: React.MouseEvent) => {
@@ -45,7 +46,10 @@ export class CanvasViewModel extends Observable {
     if (offsetX === this.endX && offsetY === this.endY) return; // 변화 없으면 무시
 
     if (!this.drawing) {
+      this.model.clearSelectedShapes();
       this.selectShapes(this.startX, this.startY, this.endX, this.endY);
+      this.notifyCanvas();
+      return;
     }
 
     this.endX = offsetX;
@@ -60,7 +64,7 @@ export class CanvasViewModel extends Observable {
       color: this.color,
     });
 
-    this.notify(this.getShapes());
+    this.notifyCanvas();
   };
 
   handleMouseUp = () => {
@@ -76,7 +80,7 @@ export class CanvasViewModel extends Observable {
         })
       ); // Model에 추가
     }
-    this.notify(this.getShapes());
+    this.notifyCanvas();
     this.drawing = false;
   };
 
@@ -93,5 +97,9 @@ export class CanvasViewModel extends Observable {
         this.model.addSelectedShapes(shape);
       }
     });
+  }
+
+  notifyCanvas() {
+    this.notify([this.getShapes(), this.model.getSelectedShapes()]);
   }
 }

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -36,15 +36,17 @@ export class CanvasViewModel extends Observable {
     this.startY = offsetY;
     this.endX = offsetX;
     this.endY = offsetY;
-    console.log(this.startX, this.startY);
-    this.drawing = true;
+
+    if (this.shapeType !== "select") this.drawing = true;
   };
 
   handleMouseMove = (event: React.MouseEvent) => {
-    if (!this.drawing) return;
-
     const { offsetX, offsetY } = event.nativeEvent;
     if (offsetX === this.endX && offsetY === this.endY) return; // 변화 없으면 무시
+
+    if (!this.drawing) {
+      this.selectShapes(this.startX, this.startY, this.endX, this.endY);
+    }
 
     this.endX = offsetX;
     this.endY = offsetY; // 실시간 반영
@@ -77,4 +79,19 @@ export class CanvasViewModel extends Observable {
     this.notify(this.getShapes());
     this.drawing = false;
   };
+
+  selectShapes(startX: number, startY: number, endX: number, endY: number) {
+    this.model.clearSelectedShapes();
+
+    this.model.getShapes().forEach((shape) => {
+      if (
+        ((startX <= shape.startX && shape.startX <= endX) ||
+          (startX <= shape.endX && shape.endX <= endX)) &&
+        ((startY <= shape.startY && shape.startY <= endY) ||
+          (startY <= shape.endY && shape.endY <= endY))
+      ) {
+        this.model.addSelectedShapes(shape);
+      }
+    });
+  }
 }

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -1,6 +1,5 @@
 import { CanvasModel } from "../model/CanvasModel";
 import React from "react";
-import { ShapeFactory } from "../entity/ShapeFactory";
 import { Observable } from "../core/Observable";
 import { Shape } from "../entity/Shape";
 import { DrawingState, ICanvasState } from "./CanvasState";

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -42,7 +42,7 @@ export class CanvasViewModel extends Observable {
     this.endY = offsetY;
 
     this.drawing = true;
-    this.model.clearSelectedShapes();
+    this.model.clearSelectedShapes(); // state 적용해도 model 메서드 호출은 뷰모델에서 하기
   };
 
   handleMouseMove = (event: React.MouseEvent) => {
@@ -89,24 +89,20 @@ export class CanvasViewModel extends Observable {
     this.drawing = false;
   };
 
-  selectShapes(startX: number, startY: number, endX: number, endY: number) {
-    this.model.clearSelectedShapes();
+  getCountShapes() {
+    return this.model.countShapes();
+  }
 
-    const minX = Math.min(startX, endX);
-    const maxX = Math.max(startX, endX);
-    const minY = Math.min(startY, endY);
-    const maxY = Math.max(startY, endY);
+  addShape(shape: Shape) {
+    return this.model.addShape(shape);
+  }
 
-    this.model.getShapes().forEach((shape) => {
-      if (
-        ((minX <= shape.startX && shape.startX <= maxX) ||
-          (minX <= shape.endX && shape.endX <= maxX)) &&
-        ((minY <= shape.startY && shape.startY <= maxY) ||
-          (minY <= shape.endY && shape.endY <= maxY))
-      ) {
-        this.model.addSelectedShapes(shape);
-      }
-    });
+  clearSelectedShapes() {
+    return this.model.clearSelectedShapes();
+  }
+
+  addSelectedShapes(shape: Shape) {
+    return this.model.addSelectedShapes(shape);
   }
 
   notifyCanvas() {

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -3,30 +3,45 @@ import React from "react";
 import { ShapeFactory } from "../entity/ShapeFactory";
 import { Observable } from "../core/Observable";
 import { Shape } from "../entity/Shape";
+import { DrawingState, ICanvasState } from "./CanvasState";
 
 export class CanvasViewModel extends Observable {
   private model: CanvasModel;
-  private drawing = false;
-  private drawingShape: Shape | null = null;
+  private state: ICanvasState;
 
-  public shapeType: string = "rectangle"; //TODO: 하나의 prop으로 정리하기?
-  private startX: number = 0;
-  private startY: number = 0;
-  private endX: number = 0;
-  private endY: number = 0;
-  private color: string = "black";
+  public shapeType: string = "rectangle";
 
   constructor(model: CanvasModel) {
     super();
     this.model = model;
+    this.state = new DrawingState(this); //default: 그리기 모드
   }
 
+  setState(state: ICanvasState) {
+    this.state = state;
+  }
+
+  handleMouseDown = (event: React.MouseEvent) => {
+    this.state.handleMouseDown(event);
+    this.model.clearSelectedShapes(); // state 적용해도 model 메서드 호출은 뷰모델에서 하기
+  };
+
+  handleMouseMove = (event: React.MouseEvent) => {
+    this.state.handleMouseMove(event);
+    this.notifyCanvas();
+  };
+
+  handleMouseUp = () => {
+    this.state.handleMouseUp();
+    this.notifyCanvas();
+  };
+
   getShapes() {
-    if (this.drawing) {
-      return this.drawingShape
-        ? [...this.model.getShapes(), this.drawingShape]
-        : this.model.getShapes();
-    }
+    return this.state.getCurrentShapes();
+  }
+
+  //모델 관련 메서드 -> state에서 참조함
+  getSavedShapes() {
     return this.model.getShapes();
   }
 
@@ -34,62 +49,7 @@ export class CanvasViewModel extends Observable {
     return this.model.getSelectedShapes();
   }
 
-  handleMouseDown = (event: React.MouseEvent) => {
-    const { offsetX, offsetY } = event.nativeEvent;
-    this.startX = offsetX;
-    this.startY = offsetY;
-    this.endX = offsetX;
-    this.endY = offsetY;
-
-    this.drawing = true;
-    this.model.clearSelectedShapes(); // state 적용해도 model 메서드 호출은 뷰모델에서 하기
-  };
-
-  handleMouseMove = (event: React.MouseEvent) => {
-    const { offsetX, offsetY } = event.nativeEvent;
-    if (offsetX === this.endX && offsetY === this.endY) return; // 변화 없으면 무시
-    if (!this.drawing) return;
-
-    this.endX = offsetX;
-    this.endY = offsetY; // 실시간 반영
-
-    if (this.shapeType === "select") {
-      this.model.clearSelectedShapes();
-      this.selectShapes(this.startX, this.startY, this.endX, this.endY);
-      this.notifyCanvas();
-      return;
-    }
-
-    this.drawingShape = ShapeFactory.createShape(this.shapeType, {
-      id: this.model.countShapes(),
-      startX: this.startX,
-      startY: this.startY,
-      endX: this.endX,
-      endY: this.endY,
-      color: this.color,
-    });
-
-    this.notifyCanvas();
-  };
-
-  handleMouseUp = () => {
-    if (this.drawing && this.shapeType !== "select") {
-      this.model.addShape(
-        ShapeFactory.createShape(this.shapeType, {
-          id: this.model.countShapes(),
-          startX: this.startX,
-          startY: this.startY,
-          endX: this.endX,
-          endY: this.endY,
-          color: this.color,
-        })
-      ); // Model에 추가
-    }
-    this.notifyCanvas();
-    this.drawing = false;
-  };
-
-  getCountShapes() {
+  countShapes() {
     return this.model.countShapes();
   }
 

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -8,7 +8,7 @@ export class CanvasViewModel extends Observable {
   private model: CanvasModel;
   private state: ICanvasState;
 
-  public shapeType: string = "rectangle";
+  private shapeType: string = "rectangle";
 
   constructor(model: CanvasModel) {
     super();
@@ -18,6 +18,10 @@ export class CanvasViewModel extends Observable {
 
   setState(state: ICanvasState) {
     this.state = state;
+  }
+
+  setShapeType(type: string) {
+    this.shapeType = type;
   }
 
   handleMouseDown = (event: React.MouseEvent) => {
@@ -37,6 +41,10 @@ export class CanvasViewModel extends Observable {
 
   getShapes() {
     return this.state.getCurrentShapes();
+  }
+
+  getShapeType() {
+    return this.shapeType;
   }
 
   //모델 관련 메서드 -> state에서 참조함


### PR DESCRIPTION
## 변경사항
- 선택 기능을 추가했습니다.
- 그리기/선택 모드를 분리하기 위해 state 패턴을 적용했습니다.
- state는 viewModel을 통해 model을 참고하도록 viewModel에 model 관련 메서드를 추가했습니다.

**선택 기능**
"선택" 라디오 버튼을 추가해 도형을 선택합니다. 선택한 영역에 도형 일부가 겹친다면 선택된 것으로 간주합니다.
아직 선택한 도형을 페이지에 표시하지는 않고, 콘솔 로그에서 확인할 수 있습니다.

**State 패턴**
객체가 조건에 따라 다른 작업을 수행하도록 상태를 객체화해 적용하는 패턴입니다. 그리기/선택 모드를 선택할때 viewModel 내부에서 실행 로직을 선택하는 것이 아니라, 설정에 따라 state를 변경해 작업을 수행합니다. 같은 인터페이스를 공유하는 DrawingState와 SelectState를 추가하고, 관련 로직을 각각 분리해 State 클래스 내부로 옮겼습니다.
이때 state가 model을 직접 참조하지 않도록, viewModel에서 model을 참조하는 메서드를 작성해 state에서 사용하도록 만들었습니다.

**다음 작업**
select랑 도형 이동, resize 기능이 연결되어있어 제가 작업하겠습니당 