### PR TITLE
도형 이동 기능 추가

### DIFF
--- a/src/Entity/Shape.ts
+++ b/src/Entity/Shape.ts
@@ -100,17 +100,3 @@ export class Ellipse implements Shape {
 }
 
 //TODO: image, line 추가
-
-// vm
-// class ShapeViewModel {
-//   createRectangle(startX: number, startY: number, endX: number, endY: number): Rectangle {
-//     const width = Math.abs(endX - startX);
-//     const height = Math.abs(endY - startY);
-//     return new Rectangle(startX, startY, width, height);
-//   }
-
-//   createCircle(centerX: number, centerY: number, endX: number, endY: number): Circle {
-//     const radius = Math.sqrt((endX - centerX) ** 2 + (endY - centerY) ** 2);
-//     return new Circle(centerX, centerY, radius);
-//   }
-// }

--- a/src/Entity/Shape.ts
+++ b/src/Entity/Shape.ts
@@ -6,7 +6,7 @@ export interface Shape {
   endY: number;
   draw(ctx: CanvasRenderingContext2D | null): void;
   //TODO: move, resize 추가
-  //move(dx: number, dy: number),
+  move(dx: number, dy: number): void;
   //resize(w: number, h:number)
 }
 
@@ -40,6 +40,13 @@ export class Rectangle implements Shape {
     if (!ctx) throw new Error("context is null");
     ctx.fillStyle = this.color;
     ctx.fillRect(this.startX, this.startY, this.width, this.height);
+  }
+
+  move(dx: number, dy: number): void {
+    this.startX += dx;
+    this.startY += dy;
+    this.endX += dx;
+    this.endY += dy;
   }
 }
 
@@ -82,6 +89,13 @@ export class Ellipse implements Shape {
       Math.PI * 2
     );
     ctx.fill();
+  }
+
+  move(dx: number, dy: number): void {
+    this.startX += dx;
+    this.startY += dy;
+    this.endX += dx;
+    this.endY += dy;
   }
 }
 

--- a/src/model/CanvasModel.ts
+++ b/src/model/CanvasModel.ts
@@ -33,7 +33,6 @@ export class CanvasModel {
   }
 
   moveSelectedShapes(dx: number, dy: number): void {
-    console.log(this.selectedShapes, dx, dy);
     return this.selectedShapes.forEach((shape) => {
       shape.move(dx, dy);
     });

--- a/src/model/CanvasModel.ts
+++ b/src/model/CanvasModel.ts
@@ -33,6 +33,7 @@ export class CanvasModel {
   }
 
   moveSelectedShapes(dx: number, dy: number): void {
+    console.log(this.selectedShapes, dx, dy);
     return this.selectedShapes.forEach((shape) => {
       shape.move(dx, dy);
     });

--- a/src/model/CanvasModel.ts
+++ b/src/model/CanvasModel.ts
@@ -31,4 +31,10 @@ export class CanvasModel {
   getSelectedShapes(): Shape[] {
     return [...this.selectedShapes];
   }
+
+  moveSelectedShapes(dx: number, dy: number): void {
+    return this.selectedShapes.forEach((shape) => {
+      shape.move(dx, dy);
+    });
+  }
 }

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -174,6 +174,7 @@ export class MoveState implements ICanvasState {
     this.selectedShapes = selectedShapes;
     this.startX = offsetX;
     this.startY = offsetY;
+    this.moving = true;
   }
 
   handleMouseDown(event: React.MouseEvent): void {
@@ -193,8 +194,8 @@ export class MoveState implements ICanvasState {
     this.endX = offsetX;
     this.endY = offsetY;
 
-    const dx = this.startX - this.endX;
-    const dy = this.startY - this.endY;
+    const dx = this.endX - this.startX;
+    const dy = this.endY - this.startY;
     this.startX = offsetX;
     this.startY = offsetY;
 

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -80,10 +80,10 @@ export class SelectState implements ICanvasState {
 
   handleMouseDown(event: React.MouseEvent): void {
     const { offsetX, offsetY } = event.nativeEvent;
-    this.viewModel.clearSelectedShapes();
 
     if (this.checkShapeClick(offsetX, offsetY)) return; // 선택한 위치에 도형이 있다면 MoveState로 전환
 
+    this.viewModel.clearSelectedShapes();
     this.startX = offsetX;
     this.startY = offsetY;
     this.endX = offsetX;
@@ -135,8 +135,26 @@ export class SelectState implements ICanvasState {
   }
 
   checkShapeClick(offsetX: number, offsetY: number): boolean {
+    const selectedShapes = this.viewModel.getSelectedShapes();
+    for (let i = 0; i < selectedShapes.length; i++) {
+      const shape = selectedShapes[i];
+      if (
+        offsetX >= Math.min(shape.startX, shape.endX) &&
+        offsetX <= Math.max(shape.startX, shape.endX) &&
+        offsetY >= Math.min(shape.startY, shape.endY) &&
+        offsetY <= Math.max(shape.startY, shape.endY)
+      ) {
+        this.viewModel.setState(
+          new MoveState(this.viewModel, offsetX, offsetY)
+        );
+        return true;
+      }
+    }
+
+    this.viewModel.clearSelectedShapes();
     const shapes = this.viewModel.getSavedShapes();
-    shapes.forEach((shape) => {
+    for (let i = 0; i < shapes.length; i++) {
+      const shape = shapes[i];
       if (
         offsetX >= Math.min(shape.startX, shape.endX) &&
         offsetX <= Math.max(shape.startX, shape.endX) &&
@@ -144,13 +162,12 @@ export class SelectState implements ICanvasState {
         offsetY <= Math.max(shape.startY, shape.endY)
       ) {
         this.viewModel.addSelectedShapes(shape); // 클릭한 도형을 선택
-        console.log("Selected shape:", this.viewModel.getSelectedShapes());
         this.viewModel.setState(
           new MoveState(this.viewModel, offsetX, offsetY)
-        ); // 이동 상태로 전환
+        );
         return true;
       }
-    });
+    }
 
     return false;
   }
@@ -187,7 +204,6 @@ export class MoveState implements ICanvasState {
     const { offsetX, offsetY } = event.nativeEvent;
     if (offsetX === this.endX && offsetY === this.endY) return;
 
-    console.log("MoveState", this.viewModel.getSelectedShapes());
     this.endX = offsetX;
     this.endY = offsetY;
 

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -22,6 +22,12 @@ export class DrawingState implements ICanvasState {
 
   handleMouseDown(event: React.MouseEvent): void {
     const { offsetX, offsetY } = event.nativeEvent;
+
+    //도형 클릭 시 이동 상태로 전환
+    if (this.checkShapeClick(offsetX, offsetY)) {
+      this.viewModel.setState(new MoveState(this.viewModel));
+      return;
+    }
     this.startX = offsetX;
     this.startY = offsetY;
     this.endX = offsetX;
@@ -67,6 +73,22 @@ export class DrawingState implements ICanvasState {
         : this.viewModel.getSavedShapes();
     }
     return this.viewModel.getSavedShapes();
+  }
+
+  checkShapeClick(offsetX: number, offsetY: number): boolean {
+    const shapes = this.viewModel.getSavedShapes();
+    shapes.forEach((shape) => {
+      if (
+        offsetX >= Math.min(shape.startX, shape.endX) &&
+        offsetX <= Math.max(shape.startX, shape.endX) &&
+        offsetY >= Math.min(shape.startY, shape.endY) &&
+        offsetY <= Math.max(shape.startY, shape.endY)
+      ) {
+        return true;
+      }
+    });
+
+    return false;
   }
 }
 

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -133,3 +133,26 @@ export class SelectState implements ICanvasState {
     return this.viewModel.getSavedShapes();
   }
 }
+
+export class MoveState implements ICanvasState {
+  private selectedShape: Shape | null = null;
+  private offsetX = 0;
+  private offsetY = 0;
+  private moving = false;
+
+  constructor(private viewModel: CanvasViewModel) {}
+
+  handleMouseDown(event: React.MouseEvent): void {
+    this.offsetX = event.clientX;
+    this.offsetX = event.clientY;
+    this.selectedShape = this.viewModel.getSelectedShapes()[0]; //TODO: 다중 선택 시 처리
+  }
+
+  handleMouseMove(event: React.MouseEvent): void {}
+
+  handleMouseUp(): void {}
+
+  getCurrentShapes(): Shape[] {
+    return this.viewModel.getSavedShapes();
+  }
+}

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -135,20 +135,42 @@ export class SelectState implements ICanvasState {
 }
 
 export class MoveState implements ICanvasState {
-  private selectedShape: Shape | null = null;
-  private offsetX = 0;
-  private offsetY = 0;
+  private selectedShapes: Shape[] | null = null;
+  private startX: number = 0;
+  private startY: number = 0;
+  private endX: number = 0;
+  private endY: number = 0;
   private moving = false;
 
   constructor(private viewModel: CanvasViewModel) {}
 
   handleMouseDown(event: React.MouseEvent): void {
-    this.offsetX = event.clientX;
-    this.offsetX = event.clientY;
-    this.selectedShape = this.viewModel.getSelectedShapes()[0]; //TODO: 다중 선택 시 처리
+    const { offsetX, offsetY } = event.nativeEvent;
+    this.startX = offsetX;
+    this.startY = offsetY;
+
+    this.selectedShapes = this.viewModel.getSelectedShapes();
+    this.moving = true;
   }
 
-  handleMouseMove(event: React.MouseEvent): void {}
+  handleMouseMove(event: React.MouseEvent): void {
+    if(!this.moving) return;
+    const { offsetX, offsetY } = event.nativeEvent;
+    if (offsetX === this.endX && offsetY === this.endY) return;
+    
+    this.endX = offsetX;
+    this.endY = offsetY;
+
+    const dx = this.startX-this.endX;
+    const dy = this.startY-this.endY;
+    this.startX = offsetX;
+    this.startY = offsetY;
+
+    if(this.selectedShapes) {
+      this.selectedShapes.forEach(shape => { shape.move(dx, dy) });
+      };
+    }
+  }
 
   handleMouseUp(): void {}
 

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -154,25 +154,28 @@ export class MoveState implements ICanvasState {
   }
 
   handleMouseMove(event: React.MouseEvent): void {
-    if(!this.moving) return;
+    if (!this.moving) return;
     const { offsetX, offsetY } = event.nativeEvent;
     if (offsetX === this.endX && offsetY === this.endY) return;
-    
+
     this.endX = offsetX;
     this.endY = offsetY;
 
-    const dx = this.startX-this.endX;
-    const dy = this.startY-this.endY;
+    const dx = this.startX - this.endX;
+    const dy = this.startY - this.endY;
     this.startX = offsetX;
     this.startY = offsetY;
 
-    if(this.selectedShapes) {
-      this.selectedShapes.forEach(shape => { shape.move(dx, dy) });
-      };
+    if (this.selectedShapes) {
+      this.viewModel.moveSelectedShapes(dx, dy); // move selected shapes
     }
   }
 
-  handleMouseUp(): void {}
+  handleMouseUp(): void {
+    this.moving = false;
+    this.selectedShapes = null; // reset selected shapes
+    this.viewModel.setState(new SelectState(this.viewModel)); // switch back to select state
+  }
 
   getCurrentShapes(): Shape[] {
     return this.viewModel.getSavedShapes();

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -71,6 +71,10 @@ export class CanvasViewModel extends Observable {
     return this.model.addSelectedShapes(shape);
   }
 
+  moveSelectedShapes(dx: number, dy: number) {
+    return this.model.moveSelectedShapes(dx, dy);
+  }
+
   notifyCanvas() {
     this.notify([this.getShapes(), this.model.getSelectedShapes()]);
   }

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -26,7 +26,6 @@ export class CanvasViewModel extends Observable {
 
   handleMouseDown = (event: React.MouseEvent) => {
     this.state.handleMouseDown(event);
-    this.model.clearSelectedShapes(); // state 적용해도 model 메서드 호출은 뷰모델에서 하기
   };
 
   handleMouseMove = (event: React.MouseEvent) => {


### PR DESCRIPTION
## 변경사항
- Shape 인터페이스에 move 메서드 추가
- 도형 이동 상태 (MoveState) 추가
- 선택, 이동 상태 전환
- 개별 이동, 다중 선택 이동 구현

**MoveState 추가, 상태 전환**
이동 상태를 분리해 구현하기 위해 MoveState를 구현했습니다.
SelectState에서 마우스 이벤트가 발생할때 경우에 따라 MoveState로 전환합니다. (MoveState의 checkShapeClick 메서드 참고)
1. 클릭한 위치가 도형 내부인 경우 
2. 도형(들)이 이미 선택된 상태에서 해당 도형을 클릭할 경우
1, 2의 경우 클릭 후 드래그 하면 자동으로 MoveState로 전환해 도형을 이동합니다.