### PR TITLE
feat/resize: 도형 크기 조절 기능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Canvas from "./view/Canvas";
 import { CanvasViewModel } from "./viewModel/CanvasViewModel";
 import { CanvasModel } from "./model/CanvasModel";
 import Toolbar from "./view/Toolbar";
+import ResizeHandle from "./view/ResizeHandle";
 
 const App: React.FC = () => {
   const model = new CanvasModel();
@@ -13,6 +14,7 @@ const App: React.FC = () => {
       {/* <h1></h1> */}
       <Canvas viewModel={viewModel} />
       <Toolbar viewModel={viewModel} />
+      <ResizeHandle viewModel={viewModel} />
     </div>
   );
 };

--- a/src/entity/Shape.ts
+++ b/src/entity/Shape.ts
@@ -52,10 +52,10 @@ export class Rectangle implements Shape {
 
   getResizeHandles(): { x: number; y: number; pos: string }[] {
     return [
-      { x: this.startX, y: this.startY, pos: "top-left" }, // top-left
-      { x: this.endX, y: this.startY, pos: "top-right" }, // top-right
-      { x: this.endX, y: this.endY, pos: "bottom-right" }, // bottom-right
-      { x: this.startX, y: this.endY, pos: "bottom-left" }, // bottom-left
+      { x: this.startX - 5, y: this.startY - 5, pos: "top-left" }, // top-left
+      { x: this.endX - 5, y: this.startY - 5, pos: "top-right" }, // top-right
+      { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" }, // bottom-right
+      { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" }, // bottom-left
     ];
   }
 
@@ -130,10 +130,10 @@ export class Ellipse implements Shape {
   }
   getResizeHandles(): { x: number; y: number; pos: string }[] {
     return [
-      { x: this.startX, y: this.startY, pos: "top-left" }, // top-left
-      { x: this.endX, y: this.startY, pos: "top-right" }, // top-right
-      { x: this.endX, y: this.endY, pos: "bottom-right" }, // bottom-right
-      { x: this.startX, y: this.endY, pos: "bottom-left" }, // bottom-left
+      { x: this.startX - 5, y: this.startY - 5, pos: "top-left" }, // top-left
+      { x: this.endX - 5, y: this.startY - 5, pos: "top-right" }, // top-right
+      { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" }, // bottom-right
+      { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" }, // bottom-left
     ];
   }
 
@@ -201,10 +201,10 @@ export class Line implements Shape {
 
   getResizeHandles(): { x: number; y: number; pos: string }[] {
     return [
-      { x: this.startX, y: this.startY, pos: "top-left" }, // top-left
-      { x: this.endX, y: this.startY, pos: "top-right" }, // top-right
-      { x: this.endX, y: this.endY, pos: "bottom-right" }, // bottom-right
-      { x: this.startX, y: this.endY, pos: "bottom-left" }, // bottom-left
+      { x: this.startX - 5, y: this.startY - 5, pos: "top-left" }, // top-left
+      { x: this.endX - 5, y: this.startY - 5, pos: "top-right" }, // top-right
+      { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" }, // bottom-right
+      { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" }, // bottom-left
     ];
   }
 

--- a/src/entity/Shape.ts
+++ b/src/entity/Shape.ts
@@ -7,8 +7,8 @@ export interface Shape {
   draw(ctx: CanvasRenderingContext2D | null): void;
   //TODO: move, resize 추가
   move(dx: number, dy: number): void;
-  getResizeHandles(): { x: number; y: number; cursor: string }[];
-  //resize(w: number, h:number)
+  getResizeHandles(): { x: number; y: number; pos: string }[];
+  resize(x: number, y: number, pos: string): void;
 }
 
 export class Rectangle implements Shape {
@@ -50,13 +50,34 @@ export class Rectangle implements Shape {
     this.endY += dy;
   }
 
-  getResizeHandles(): { x: number; y: number; cursor: string }[] {
+  getResizeHandles(): { x: number; y: number; pos: string }[] {
     return [
-      { x: this.startX, y: this.startY, cursor: "nwse-resize" }, // top-left
-      { x: this.endX, y: this.startY, cursor: "nesw-resize" }, // top-right
-      { x: this.endX, y: this.endY, cursor: "nwse-resize" }, // bottom-right
-      { x: this.startX, y: this.endY, cursor: "nesw-resize" }, // bottom-left
+      { x: this.startX, y: this.startY, pos: "top-left" }, // top-left
+      { x: this.endX, y: this.startY, pos: "top-right" }, // top-right
+      { x: this.endX, y: this.endY, pos: "bottom-right" }, // bottom-right
+      { x: this.startX, y: this.endY, pos: "bottom-left" }, // bottom-left
     ];
+  }
+
+  resize(x: number, y: number, pos: string): void {
+    switch (pos) {
+      case "top-left":
+        this.startX = x;
+        this.startY = y;
+        break;
+      case "top-right":
+        this.endX = x;
+        this.startY = y;
+        break;
+      case "bottom-right":
+        this.endX = x;
+        this.endY = y;
+        break;
+      case "bottom-left":
+        this.startX = x;
+        this.endY = y;
+        break;
+    }
   }
 }
 
@@ -107,13 +128,34 @@ export class Ellipse implements Shape {
     this.endX += dx;
     this.endY += dy;
   }
-  getResizeHandles(): { x: number; y: number; cursor: string }[] {
+  getResizeHandles(): { x: number; y: number; pos: string }[] {
     return [
-      { x: this.startX, y: this.startY, cursor: "nwse-resize" }, // top-left
-      { x: this.endX, y: this.startY, cursor: "nesw-resize" }, // top-right
-      { x: this.endX, y: this.endY, cursor: "nwse-resize" }, // bottom-right
-      { x: this.startX, y: this.endY, cursor: "nesw-resize" }, // bottom-left
+      { x: this.startX, y: this.startY, pos: "top-left" }, // top-left
+      { x: this.endX, y: this.startY, pos: "top-right" }, // top-right
+      { x: this.endX, y: this.endY, pos: "bottom-right" }, // bottom-right
+      { x: this.startX, y: this.endY, pos: "bottom-left" }, // bottom-left
     ];
+  }
+
+  resize(x: number, y: number, pos: string): void {
+    switch (pos) {
+      case "top-left":
+        this.startX = x;
+        this.startY = y;
+        break;
+      case "top-right":
+        this.endX = x;
+        this.startY = y;
+        break;
+      case "bottom-right":
+        this.endX = x;
+        this.endY = y;
+        break;
+      case "bottom-left":
+        this.startX = x;
+        this.endY = y;
+        break;
+    }
   }
 }
 
@@ -157,13 +199,34 @@ export class Line implements Shape {
     this.endY += dy;
   }
 
-  getResizeHandles(): { x: number; y: number; cursor: string }[] {
+  getResizeHandles(): { x: number; y: number; pos: string }[] {
     return [
-      { x: this.startX, y: this.startY, cursor: "nwse-resize" }, // top-left
-      { x: this.endX, y: this.startY, cursor: "nesw-resize" }, // top-right
-      { x: this.endX, y: this.endY, cursor: "nwse-resize" }, // bottom-right
-      { x: this.startX, y: this.endY, cursor: "nesw-resize" }, // bottom-left
+      { x: this.startX, y: this.startY, pos: "top-left" }, // top-left
+      { x: this.endX, y: this.startY, pos: "top-right" }, // top-right
+      { x: this.endX, y: this.endY, pos: "bottom-right" }, // bottom-right
+      { x: this.startX, y: this.endY, pos: "bottom-left" }, // bottom-left
     ];
+  }
+
+  resize(x: number, y: number, pos: string): void {
+    switch (pos) {
+      case "top-left":
+        this.startX = x;
+        this.startY = y;
+        break;
+      case "top-right":
+        this.endX = x;
+        this.startY = y;
+        break;
+      case "bottom-right":
+        this.endX = x;
+        this.endY = y;
+        break;
+      case "bottom-left":
+        this.startX = x;
+        this.endY = y;
+        break;
+    }
   }
 }
 

--- a/src/entity/Shape.ts
+++ b/src/entity/Shape.ts
@@ -8,7 +8,7 @@ export interface Shape {
   //TODO: move, resize 추가
   move(dx: number, dy: number): void;
   getResizeHandles(): { x: number; y: number; pos: string }[];
-  resize(x: number, y: number, pos: string): void;
+  resize(dx: number, dy: number, pos: string): void;
 }
 
 export class Rectangle implements Shape {
@@ -59,23 +59,23 @@ export class Rectangle implements Shape {
     ];
   }
 
-  resize(x: number, y: number, pos: string): void {
+  resize(dx: number, dy: number, pos: string): void {
     switch (pos) {
       case "top-left":
-        this.startX = x;
-        this.startY = y;
+        this.startX += dx;
+        this.startY += dy;
         break;
       case "top-right":
-        this.endX = x;
-        this.startY = y;
+        this.endX += dx;
+        this.startY += dy;
         break;
       case "bottom-right":
-        this.endX = x;
-        this.endY = y;
+        this.endX += dx;
+        this.endY += dy;
         break;
       case "bottom-left":
-        this.startX = x;
-        this.endY = y;
+        this.startX += dx;
+        this.endY += dy;
         break;
     }
   }
@@ -137,23 +137,23 @@ export class Ellipse implements Shape {
     ];
   }
 
-  resize(x: number, y: number, pos: string): void {
+  resize(dx: number, dy: number, pos: string): void {
     switch (pos) {
       case "top-left":
-        this.startX = x;
-        this.startY = y;
+        this.startX += dx;
+        this.startY += dy;
         break;
       case "top-right":
-        this.endX = x;
-        this.startY = y;
+        this.endX += dx;
+        this.startY += dy;
         break;
       case "bottom-right":
-        this.endX = x;
-        this.endY = y;
+        this.endX += dx;
+        this.endY += dy;
         break;
       case "bottom-left":
-        this.startX = x;
-        this.endY = y;
+        this.startX += dx;
+        this.endY += dy;
         break;
     }
   }
@@ -208,23 +208,23 @@ export class Line implements Shape {
     ];
   }
 
-  resize(x: number, y: number, pos: string): void {
+  resize(dx: number, dy: number, pos: string): void {
     switch (pos) {
       case "top-left":
-        this.startX = x;
-        this.startY = y;
+        this.startX += dx;
+        this.startY += dy;
         break;
       case "top-right":
-        this.endX = x;
-        this.startY = y;
+        this.endX += dx;
+        this.startY += dy;
         break;
       case "bottom-right":
-        this.endX = x;
-        this.endY = y;
+        this.endX += dx;
+        this.endY += dy;
         break;
       case "bottom-left":
-        this.startX = x;
-        this.endY = y;
+        this.startX += dx;
+        this.endY += dy;
         break;
     }
   }

--- a/src/entity/Shape.ts
+++ b/src/entity/Shape.ts
@@ -7,6 +7,7 @@ export interface Shape {
   draw(ctx: CanvasRenderingContext2D | null): void;
   //TODO: move, resize 추가
   move(dx: number, dy: number): void;
+  getResizeHandles(): { x: number; y: number; cursor: string }[];
   //resize(w: number, h:number)
 }
 
@@ -47,6 +48,15 @@ export class Rectangle implements Shape {
     this.startY += dy;
     this.endX += dx;
     this.endY += dy;
+  }
+
+  getResizeHandles(): { x: number; y: number; cursor: string }[] {
+    return [
+      { x: this.startX, y: this.startY, cursor: "nwse-resize" }, // top-left
+      { x: this.endX, y: this.startY, cursor: "nesw-resize" }, // top-right
+      { x: this.endX, y: this.endY, cursor: "nwse-resize" }, // bottom-right
+      { x: this.startX, y: this.endY, cursor: "nesw-resize" }, // bottom-left
+    ];
   }
 }
 
@@ -97,6 +107,14 @@ export class Ellipse implements Shape {
     this.endX += dx;
     this.endY += dy;
   }
+  getResizeHandles(): { x: number; y: number; cursor: string }[] {
+    return [
+      { x: this.startX, y: this.startY, cursor: "nwse-resize" }, // top-left
+      { x: this.endX, y: this.startY, cursor: "nesw-resize" }, // top-right
+      { x: this.endX, y: this.endY, cursor: "nwse-resize" }, // bottom-right
+      { x: this.startX, y: this.endY, cursor: "nesw-resize" }, // bottom-left
+    ];
+  }
 }
 
 export class Line implements Shape {
@@ -138,6 +156,15 @@ export class Line implements Shape {
     this.endX += dx;
     this.endY += dy;
   }
+
+  getResizeHandles(): { x: number; y: number; cursor: string }[] {
+    return [
+      { x: this.startX, y: this.startY, cursor: "nwse-resize" }, // top-left
+      { x: this.endX, y: this.startY, cursor: "nesw-resize" }, // top-right
+      { x: this.endX, y: this.endY, cursor: "nwse-resize" }, // bottom-right
+      { x: this.startX, y: this.endY, cursor: "nesw-resize" }, // bottom-left
+    ];
+  }
 }
 
-//TODO: image, line 추가
+//TODO: image 추가

--- a/src/model/CanvasModel.ts
+++ b/src/model/CanvasModel.ts
@@ -37,4 +37,8 @@ export class CanvasModel {
       shape.move(dx, dy);
     });
   }
+
+  getSelectedShapesHandles(): { x: number; y: number; cursor: string }[][] {
+    return this.selectedShapes.map((shape) => shape.getResizeHandles());
+  }
 }

--- a/src/model/CanvasModel.ts
+++ b/src/model/CanvasModel.ts
@@ -38,7 +38,13 @@ export class CanvasModel {
     });
   }
 
-  getSelectedShapesHandles(): { x: number; y: number; cursor: string }[][] {
+  getSelectedShapesHandles(): { x: number; y: number; pos: string }[][] {
     return this.selectedShapes.map((shape) => shape.getResizeHandles());
+  }
+
+  resizeSelectedShapes(x: number, y: number, pos: string): void {
+    return this.selectedShapes.forEach((shape) => {
+      shape.resize(x, y, pos);
+    });
   }
 }

--- a/src/view/Canvas.tsx
+++ b/src/view/Canvas.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { CanvasViewModel } from "../viewModel/CanvasViewModel";
 import { Shape } from "../entity/Shape";
+import ResizeHandle from "./ResizeHandle";
 
 const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -26,6 +27,7 @@ const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
     };
   }, []);
 
+  //캔버스 렌더링
   const redrawCanvas = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;

--- a/src/view/ResizeHandle.tsx
+++ b/src/view/ResizeHandle.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect } from "react";
+import { CanvasViewModel } from "../viewModel/CanvasViewModel";
+import { Shape } from "../entity/Shape";
+
+const ResizeHandle: React.FC<{ viewModel: CanvasViewModel }> = ({
+  viewModel,
+}) => {
+  const [selectedShapes, setSelectedShapes] = React.useState(
+    viewModel.getSelectedShapes()
+  );
+
+  useEffect(() => {
+    const observer = {
+      update: (updatedShapes: Shape[][]) => {
+        const selectedShape = updatedShapes[1];
+        setSelectedShapes([...selectedShape]);
+      },
+    };
+    viewModel.subscribe(observer);
+    return () => {
+      viewModel.unsubscribe(observer);
+    };
+  }, []);
+
+  return selectedShapes.map((shape) => (
+    <React.Fragment key={shape.id}>
+      <>
+        {shape.getResizeHandles().map((handle) => (
+          <div
+            key={shape.id + handle.pos}
+            className="resize-handle"
+            style={{
+              position: "absolute",
+              left: handle.x,
+              top: handle.y,
+              width: 10,
+              height: 10,
+              backgroundColor: "blue",
+              cursor: "pointer",
+            }}
+            onMouseDown={(e) => viewModel.startResizing(handle, e)}
+          />
+        ))}
+      </>
+    </React.Fragment>
+  ));
+};
+
+export default ResizeHandle;

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -234,14 +234,20 @@ export class MoveState implements ICanvasState {
 export class ResizeState implements ICanvasState {
   private selectedShapes: Shape[] = [];
   private resizing: boolean = false;
+  private startX: number = 0;
+  private startY: number = 0;
   constructor(
     private viewModel: CanvasViewModel,
-    private pos: string // "top-left", "top-right", "bottom-right", "bottom-left"
+    private pos: string, // "top-left", "top-right", "bottom-right", "bottom-left"
+    offsetX: number,
+    offsetY: number
   ) {
     this.selectedShapes = this.viewModel.getSelectedShapes();
     this.resizing = true;
 
     document.addEventListener("mouseup", this.handleMouseUpBound);
+    this.startX = offsetX; // offsetX - rect.left
+    this.startY = offsetY; // offsetY - rect.top
   }
   private handleMouseUpBound = this.handleMouseUp.bind(this);
   handleMouseDown(event: React.MouseEvent): void {
@@ -251,7 +257,15 @@ export class ResizeState implements ICanvasState {
   handleMouseMove(event: React.MouseEvent): void {
     if (!this.resizing) return;
     const { offsetX, offsetY } = event.nativeEvent;
-    this.viewModel.resizeSelectedShapes(offsetX, offsetY, this.pos); // resize selected shapes
+
+    if (offsetX === this.startX && offsetY === this.startY) return; // 변화 없으면 무시
+
+    const dx = offsetX - this.startX;
+    const dy = offsetY - this.startY;
+    this.viewModel.resizeSelectedShapes(dx, dy, this.pos); // resize selected shapes
+
+    this.startX = offsetX;
+    this.startY = offsetY;
   }
 
   handleMouseUp(): void {

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -226,3 +226,30 @@ export class MoveState implements ICanvasState {
     return this.viewModel.getSavedShapes();
   }
 }
+
+export class ResizeState implements ICanvasState {
+  private selectedShapes: Shape[] = [];
+  constructor(
+    private viewModel: CanvasViewModel,
+    private pos: string // "top-left", "top-right", "bottom-right", "bottom-left"
+  ) {
+    this.selectedShapes = this.viewModel.getSelectedShapes();
+  }
+
+  handleMouseDown(event: React.MouseEvent) {
+    return;
+  }
+
+  handleMouseMove(event: React.MouseEvent) {
+    const { offsetX, offsetY } = event.nativeEvent;
+    this.viewModel.resizeSelectedShapes(offsetX, offsetY, this.pos); // resize selected shapes
+  }
+
+  handleMouseUp() {
+    this.viewModel.setState(new SelectState(this.viewModel));
+  }
+
+  getCurrentShapes(): Shape[] {
+    return this.viewModel.getSavedShapes();
+  }
+}

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -10,6 +10,7 @@ export interface ICanvasState {
   getCurrentShapes(): Shape[];
 }
 
+// 그리기 모드
 export class DrawingState implements ICanvasState {
   private startX = 0;
   private startY = 0;
@@ -70,6 +71,7 @@ export class DrawingState implements ICanvasState {
   }
 }
 
+// 선택 모드
 export class SelectState implements ICanvasState {
   private startX = 0;
   private startY = 0;
@@ -173,6 +175,7 @@ export class SelectState implements ICanvasState {
   }
 }
 
+// 이동 모드
 export class MoveState implements ICanvasState {
   private startX: number = 0;
   private startY: number = 0;
@@ -227,25 +230,33 @@ export class MoveState implements ICanvasState {
   }
 }
 
+// 리사이즈 모드
 export class ResizeState implements ICanvasState {
   private selectedShapes: Shape[] = [];
+  private resizing: boolean = false;
   constructor(
     private viewModel: CanvasViewModel,
     private pos: string // "top-left", "top-right", "bottom-right", "bottom-left"
   ) {
     this.selectedShapes = this.viewModel.getSelectedShapes();
+    this.resizing = true;
+
+    document.addEventListener("mouseup", this.handleMouseUpBound);
+  }
+  private handleMouseUpBound = this.handleMouseUp.bind(this);
+  handleMouseDown(event: React.MouseEvent): void {
+    this.resizing = false;
   }
 
-  handleMouseDown(event: React.MouseEvent) {
-    return;
-  }
-
-  handleMouseMove(event: React.MouseEvent) {
+  handleMouseMove(event: React.MouseEvent): void {
+    if (!this.resizing) return;
     const { offsetX, offsetY } = event.nativeEvent;
     this.viewModel.resizeSelectedShapes(offsetX, offsetY, this.pos); // resize selected shapes
   }
 
-  handleMouseUp() {
+  handleMouseUp(): void {
+    this.resizing = false;
+    document.removeEventListener("mouseup", this.handleMouseUpBound);
     this.viewModel.setState(new SelectState(this.viewModel));
   }
 

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -43,7 +43,18 @@ export class CanvasViewModel extends Observable {
     event: React.MouseEvent
   ): void {
     event.stopPropagation(); // 부모 요소의 이벤트가 발생하지 않도록 함
-    return this.setState(new ResizeState(this, handle.pos));
+    const canvas = (
+      event.currentTarget as HTMLCanvasElement
+    ).getBoundingClientRect();
+    if (!canvas) return;
+    return this.setState(
+      new ResizeState(
+        this,
+        handle.pos,
+        canvas.left - event.nativeEvent.offsetX,
+        canvas.top - event.nativeEvent.offsetY
+      )
+    );
   }
 
   getShapes() {

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -2,7 +2,7 @@ import { CanvasModel } from "../model/CanvasModel";
 import React from "react";
 import { Observable } from "../core/Observable";
 import { Shape } from "../entity/Shape";
-import { DrawingState, ICanvasState } from "./CanvasState";
+import { DrawingState, ICanvasState, ResizeState } from "./CanvasState";
 
 export class CanvasViewModel extends Observable {
   private model: CanvasModel;
@@ -37,6 +37,15 @@ export class CanvasViewModel extends Observable {
     this.state.handleMouseUp();
     this.notifyCanvas();
   };
+
+  startResizing(
+    handle: { x: number; y: number; pos: string },
+    event: React.MouseEvent
+  ) {
+    event.stopPropagation(); // 부모 요소의 이벤트가 발생하지 않도록 함
+    this.setState(new ResizeState(this, handle.pos));
+    this.state.handleMouseDown(event);
+  }
 
   getShapes() {
     return this.state.getCurrentShapes();
@@ -73,6 +82,10 @@ export class CanvasViewModel extends Observable {
 
   moveSelectedShapes(dx: number, dy: number) {
     return this.model.moveSelectedShapes(dx, dy);
+  }
+
+  resizeSelectedShapes(x: number, y: number, pos: string) {
+    return this.model.resizeSelectedShapes(x, y, pos);
   }
 
   notifyCanvas() {

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -41,10 +41,9 @@ export class CanvasViewModel extends Observable {
   startResizing(
     handle: { x: number; y: number; pos: string },
     event: React.MouseEvent
-  ) {
+  ): void {
     event.stopPropagation(); // 부모 요소의 이벤트가 발생하지 않도록 함
-    this.setState(new ResizeState(this, handle.pos));
-    this.state.handleMouseDown(event);
+    return this.setState(new ResizeState(this, handle.pos));
   }
 
   getShapes() {


### PR DESCRIPTION
## 변경사항
- 도형 선택 시 크기 조절 핸들 추가
- 도형 크기 조절 기능 추가: 단일/다중 크기 조절

**크기 조절 핸들**
선택 모드에서 선택된 도형 왼쪽 위, 오른쪽 위, 왼쪽 아래, 오른쪽 아래 꼭짓점에 핸들을 표시합니다.
이를 추가하기 위해 Shape 인터페이스에 getResizingHandle (핸들 포지션 계산) 메서드를 추가하고, resizeHandle 뷰를 추가했습니다.
ResizeHandle 역시 viewModel을 구독해 선택 도형 정보가 변경되면 자동으로 핸들 표시 / 위치 조정을 실행합니다.

**도형 크기 조절 기능**
선택된 도형의 resize handle을 누르고 드래그하면, viewModel이 ResizeState로 전환되어 선택된 도형의 크기를 수정합니다.
현재 잡고있는 resize handle의 위치와 마우스 위치 변화(dx, dy)를 계산해 마우스가 움직인 방향으로 크기를 조정합니다.
이런 방식으로 도형 다중 선택 시에도 각각 크기를 수정할 수 있습니다.
![GIF 2025-04-10 오후 3-08-37](https://github.com/user-attachments/assets/d3117305-b508-49a9-ac1c-163dc52e9837)

이거 사실 원래는 선택 범위에 핸들 달아서 resize 할때 비율 계산해서 도형 크기 수정해야 하는데... 다중 선택 리사이징이 필수 기능은 아니라서 좀 미뤄두겠습니당