### PR TITLE
Shape 내부 클릭, Notify 분리, Toolbar 기능 추가

### DIFF
--- a/src/core/Observable.ts
+++ b/src/core/Observable.ts
@@ -1,25 +1,20 @@
 import { Observer } from "./Observer";
+import { CanvasEvent } from "../viewModel/CanvasEvents";
 
-interface ObservableInterface {
-  subscribe(observer: Observer): void;
-  unsubscribe(observer: Observer): void;
-  notify(data: any): void;
-}
+class Observable<T> {
+  private observers: Observer<CanvasEvent<T>>[] = [];
 
-class Observable implements ObservableInterface {
-  private observers: Observer[] = [];
-
-  subscribe(observer: Observer): void {
+  subscribe(observer: Observer<CanvasEvent<T>>): void {
     this.observers.push(observer);
   }
 
-  unsubscribe(observer: Observer): void {
+  unsubscribe(observer: Observer<CanvasEvent<T>>): void {
     this.observers = this.observers.filter((obs) => obs !== observer);
   }
 
-  notify(data: any): void {
-    this.observers.forEach((observer) => observer.update(data));
+  notify(event: CanvasEvent<T>): void {
+    this.observers.forEach((observer) => observer.update(event));
   }
 }
 
-export { ObservableInterface, Observable };
+export { Observable };

--- a/src/core/Observer.ts
+++ b/src/core/Observer.ts
@@ -1,5 +1,5 @@
-interface Observer {
-  update: (data: any) => void;
+interface Observer<T> {
+  update: (data: T) => void;
 }
 
 export { Observer };

--- a/src/entity/Shape.ts
+++ b/src/entity/Shape.ts
@@ -81,7 +81,6 @@ export class Rectangle implements Shape {
   }
 
   isPointInside(x: number, y: number): boolean {
-    console.log("hello?")
     return (
       x >= Math.min(this.startX, this.endX) &&
       x <= Math.max(this.startX, this.endX) &&

--- a/src/entity/Shape.ts
+++ b/src/entity/Shape.ts
@@ -5,10 +5,10 @@ export interface Shape {
   endX: number;
   endY: number;
   draw(ctx: CanvasRenderingContext2D | null): void;
-  //TODO: move, resize 추가
   move(dx: number, dy: number): void;
   getResizeHandles(): { x: number; y: number; pos: string }[];
   resize(dx: number, dy: number, pos: string): void;
+  isPointInside(x: number, y: number): boolean;
 }
 
 export class Rectangle implements Shape {
@@ -78,6 +78,16 @@ export class Rectangle implements Shape {
         this.endY += dy;
         break;
     }
+  }
+
+  isPointInside(x: number, y: number): boolean {
+    console.log("hello?")
+    return (
+      x >= Math.min(this.startX, this.endX) &&
+      x <= Math.max(this.startX, this.endX) &&
+      y >= Math.min(this.startY, this.endY) &&
+      y <= Math.max(this.startY, this.endY)
+    );
   }
 }
 
@@ -157,6 +167,20 @@ export class Ellipse implements Shape {
         break;
     }
   }
+
+  isPointInside(x: number, y: number): boolean {
+    const centerX = this.centerX;
+    const centerY = this.centerY;
+    const radiusX = this.radiusX;
+    const radiusY = this.radiusY;
+
+    // 타원의 방정식
+    return (
+      Math.pow(x - centerX, 2) / Math.pow(radiusX, 2) +
+        Math.pow(y - centerY, 2) / Math.pow(radiusY, 2) <=
+      1
+    );
+  }
 }
 
 export class Line implements Shape {
@@ -227,6 +251,27 @@ export class Line implements Shape {
         this.endY += dy;
         break;
     }
+  }
+
+  isPointInside(x: number, y: number, tolerance: number = 5): boolean {
+    // 직선의 방정식 ax + by + c = 0
+    const a = this.endY - this.startY; // dy
+    const b = this.startX - this.endX; // -dx
+    const c = this.endX * this.startY - this.startX * this.endY; // 상수항
+
+    // 점과 직선 사이의 거리 공식
+    const distance = Math.abs(a * x + b * y + c) / Math.sqrt(a * a + b * b);
+
+    // 점이 선의 범위 있는지 확인
+    const withinBounds =
+      x >= Math.min(this.startX, this.endX) - tolerance &&
+      x <= Math.max(this.startX, this.endX) + tolerance &&
+      y >= Math.min(this.startY, this.endY) - tolerance &&
+      y <= Math.max(this.startY, this.endY) + tolerance;
+
+    // 점이 "직선"과 가까운지
+    // 선 박스 내에 있는지
+    return distance <= tolerance && withinBounds;
   }
 }
 

--- a/src/hooks/useCanvasEvent.ts
+++ b/src/hooks/useCanvasEvent.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { CanvasViewModel } from "../viewModel/CanvasViewModel";
+import { CanvasEvent } from "../viewModel/CanvasEvents";
+
+function useCanvasEvent<T>(
+  viewModel: CanvasViewModel,
+  eventType: string,
+  initialState: T,
+  key: keyof T
+): T[keyof T] {
+  const [state, setState] = useState<T[keyof T]>(initialState[key]);
+
+  useEffect(() => {
+    const observer = {
+      update: (event: CanvasEvent<any>) => {
+        if (event.type === eventType && event.data[key] !== undefined) {
+          setState(event.data[key]);
+        }
+      },
+    };
+
+    viewModel.subscribe(observer);
+    return () => {
+      viewModel.unsubscribe(observer);
+    };
+  }, [viewModel, eventType, key]);
+
+  return state;
+}
+
+export default useCanvasEvent;

--- a/src/view/Canvas.tsx
+++ b/src/view/Canvas.tsx
@@ -1,31 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { CanvasViewModel } from "../viewModel/CanvasViewModel";
 import { Shape } from "../entity/Shape";
-import ResizeHandle from "./ResizeHandle";
+import useCanvasEvent from "../hooks/useCanvasEvent";
 
 const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [shapes, setShapes] = useState<Shape[]>(viewModel.getShapes());
-  const [selectedShapes, setSelectedShapes] = useState<Shape[]>(
-    viewModel.getSelectedShapes()
+  
+  const shapes = useCanvasEvent<{ shapes: Shape[]; selectedShapes: Shape[] }>(
+    viewModel,
+    "SHAPES_UPDATED",
+    { shapes: [], selectedShapes: [] },
+    "shapes"
   );
-
-  //set observer
-  useEffect(() => {
-    const observer = {
-      update: (updatedShapes: Shape[][]) => {
-        const drawShapes = updatedShapes[0];
-        const selectedShape = updatedShapes[1];
-        setShapes([...drawShapes]);
-        setSelectedShapes([...selectedShape]);
-      },
-    };
-    viewModel.subscribe(observer);
-
-    return () => {
-      viewModel.unsubscribe(observer);
-    };
-  }, []);
 
   //캔버스 렌더링
   const redrawCanvas = useCallback(() => {
@@ -46,7 +32,7 @@ const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
     if (canvasRef.current) {
       redrawCanvas();
     }
-  }, [canvasRef, redrawCanvas]);
+  }, [shapes, canvasRef, redrawCanvas]);
 
   return (
     <canvas

--- a/src/view/ResizeHandle.tsx
+++ b/src/view/ResizeHandle.tsx
@@ -1,26 +1,17 @@
 import React, { useEffect } from "react";
 import { CanvasViewModel } from "../viewModel/CanvasViewModel";
 import { Shape } from "../entity/Shape";
+import useCanvasEvent from "../hooks/useCanvasEvent";
 
 const ResizeHandle: React.FC<{ viewModel: CanvasViewModel }> = ({
   viewModel,
 }) => {
-  const [selectedShapes, setSelectedShapes] = React.useState(
-    viewModel.getSelectedShapes()
+  const selectedShapes = useCanvasEvent<{ shapes: Shape[]; selectedShapes: Shape[] }>(
+    viewModel,
+    "SHAPES_UPDATED",
+    { shapes: [], selectedShapes: [] },
+    "selectedShapes"
   );
-
-  useEffect(() => {
-    const observer = {
-      update: (updatedShapes: Shape[][]) => {
-        const selectedShape = updatedShapes[1];
-        setSelectedShapes([...selectedShape]);
-      },
-    };
-    viewModel.subscribe(observer);
-    return () => {
-      viewModel.unsubscribe(observer);
-    };
-  }, []);
 
   return selectedShapes.map((shape) => (
     <React.Fragment key={shape.id}>

--- a/src/view/Toolbar.css
+++ b/src/view/Toolbar.css
@@ -5,6 +5,7 @@
   padding: 10px;
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  user-select: none;
 }
 
 .tool-button {

--- a/src/view/Toolbar.tsx
+++ b/src/view/Toolbar.tsx
@@ -67,6 +67,15 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
       >
         선택
       </button>
+      
+      <button
+        className={`tool-button`}
+        onClick={() => {
+          viewModel.resetCanvas();
+        }}
+      >
+        리셋
+      </button>
     </div>
   );
 };

--- a/src/view/Toolbar.tsx
+++ b/src/view/Toolbar.tsx
@@ -1,15 +1,35 @@
 import React from "react";
 import { CanvasViewModel } from "../viewModel/CanvasViewModel";
 import { DrawingState, SelectState } from "../viewModel/CanvasState";
+import useCanvasEvent from "../hooks/useCanvasEvent";
 import "./Toolbar.css";
 
-const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({
-  viewModel,
-}) => {
+const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
+  const initialState = { currentState: "DrawingState", drawingShape: "rectangle" } // 초기 상태 설정
+
+  const currentState = useCanvasEvent<{ currentState: string; drawingShape?: string }>(
+    viewModel,
+    "STATE_CHANGED",
+    initialState,
+    "currentState"
+  );
+
+  const drawingShape = useCanvasEvent<{ currentState: string; drawingShape?: string }>(
+    viewModel,
+    "STATE_CHANGED",
+    initialState,
+    "drawingShape"
+  );
+
+  const isActive = (shapeType: string) =>
+    currentState === "DrawingState" && drawingShape === shapeType;
+
+  const isSelectActive = () => currentState === "SelectState";
+
   return (
     <div className="toolbar">
       <button
-        className='tool-button'
+        className={`tool-button ${isActive("rectangle") ? "active" : ""}`}
         onClick={() => {
           viewModel.setShapeType("rectangle");
           viewModel.setState(new DrawingState(viewModel));
@@ -19,7 +39,7 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({
       </button>
 
       <button
-        className='tool-button'
+        className={`tool-button ${isActive("ellipse") ? "active" : ""}`}
         onClick={() => {
           viewModel.setShapeType("ellipse");
           viewModel.setState(new DrawingState(viewModel));
@@ -29,7 +49,7 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({
       </button>
 
       <button
-        className='tool-button'
+        className={`tool-button ${isActive("line") ? "active" : ""}`}
         onClick={() => {
           viewModel.setShapeType("line");
           viewModel.setState(new DrawingState(viewModel));
@@ -39,7 +59,7 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({
       </button>
 
       <button
-        className='tool-button'
+        className={`tool-button ${isSelectActive() ? "active" : ""}`}
         onClick={() => {
           viewModel.setShapeType("select");
           viewModel.setState(new SelectState(viewModel));

--- a/src/view/Toolbar.tsx
+++ b/src/view/Toolbar.tsx
@@ -24,7 +24,7 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
   const isActive = (shapeType: string) =>
     currentState === "DrawingState" && drawingShape === shapeType;
 
-  const isSelectActive = () => currentState === "SelectState";
+  const isSelectActive = () => currentState === "SelectState" || currentState === "MoveState";
 
   return (
     <div className="toolbar">

--- a/src/viewModel/CanvasEvents.ts
+++ b/src/viewModel/CanvasEvents.ts
@@ -1,0 +1,6 @@
+export type CanvasEventType = "SHAPES_UPDATED" | "STATE_CHANGED";
+
+export interface CanvasEvent<T> {
+  type: CanvasEventType;
+  data: T;
+}

--- a/src/viewModel/CanvasState.ts
+++ b/src/viewModel/CanvasState.ts
@@ -140,12 +140,7 @@ export class SelectState implements ICanvasState {
     const selectedShapes = this.viewModel.getSelectedShapes();
     for (let i = 0; i < selectedShapes.length; i++) {
       const shape = selectedShapes[i];
-      if (
-        offsetX >= Math.min(shape.startX, shape.endX) &&
-        offsetX <= Math.max(shape.startX, shape.endX) &&
-        offsetY >= Math.min(shape.startY, shape.endY) &&
-        offsetY <= Math.max(shape.startY, shape.endY)
-      ) {
+      if (shape.isPointInside(offsetX, offsetY)) {
         this.viewModel.setState(
           new MoveState(this.viewModel, offsetX, offsetY)
         );
@@ -157,12 +152,7 @@ export class SelectState implements ICanvasState {
     const shapes = this.viewModel.getSavedShapes();
     for (let i = 0; i < shapes.length; i++) {
       const shape = shapes[i];
-      if (
-        offsetX >= Math.min(shape.startX, shape.endX) &&
-        offsetX <= Math.max(shape.startX, shape.endX) &&
-        offsetY >= Math.min(shape.startY, shape.endY) &&
-        offsetY <= Math.max(shape.startY, shape.endY)
-      ) {
+      if (shape.isPointInside(offsetX, offsetY)) {
         this.viewModel.addSelectedShapes(shape); // 클릭한 도형을 선택
         this.viewModel.setState(
           new MoveState(this.viewModel, offsetX, offsetY)

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -40,6 +40,14 @@ export class CanvasViewModel extends Observable<any> {
     this.notifyShapesUpdated();
   };
 
+  resetCanvas() {
+    this.clearShapes();
+    this.clearSelectedShapes();
+    this.setShapeType("rectangle"); // default 값으로
+    this.setState(new DrawingState(this));
+    this.notifyShapesUpdated();
+  }
+
   startResizing(
     handle: { x: number; y: number; pos: string },
     event: React.MouseEvent
@@ -82,6 +90,10 @@ export class CanvasViewModel extends Observable<any> {
 
   addShape(shape: Shape) {
     return this.model.addShape(shape);
+  }
+
+  clearShapes() {
+    return this.model.clearShapes();
   }
 
   clearSelectedShapes() {

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -3,8 +3,9 @@ import React from "react";
 import { Observable } from "../core/Observable";
 import { Shape } from "../entity/Shape";
 import { DrawingState, ICanvasState, ResizeState } from "./CanvasState";
+import { CanvasEvent } from "./CanvasEvents";
 
-export class CanvasViewModel extends Observable {
+export class CanvasViewModel extends Observable<any> {
   private model: CanvasModel;
   private state: ICanvasState;
 
@@ -30,12 +31,12 @@ export class CanvasViewModel extends Observable {
 
   handleMouseMove = (event: React.MouseEvent) => {
     this.state.handleMouseMove(event);
-    this.notifyCanvas();
+    this.notifyShapesUpdated();
   };
 
   handleMouseUp = () => {
     this.state.handleMouseUp();
-    this.notifyCanvas();
+    this.notifyShapesUpdated();
   };
 
   startResizing(
@@ -98,7 +99,24 @@ export class CanvasViewModel extends Observable {
     return this.model.resizeSelectedShapes(x, y, pos);
   }
 
-  notifyCanvas() {
-    this.notify([this.getShapes(), this.model.getSelectedShapes()]);
+  notifyShapesUpdated() {
+    const event: CanvasEvent<{ shapes: Shape[]; selectedShapes: Shape[] }> = {
+      type: "SHAPES_UPDATED",
+      data: {
+        shapes: this.getShapes(),
+        selectedShapes: this.model.getSelectedShapes(),
+      },
+    };
+    this.notify(event);
+  }
+
+  notifyStateChanged() {
+    const event: CanvasEvent<{ currentState: string }> = {
+      type: "STATE_CHANGED",
+      data: {
+        currentState: this.state.constructor.name,
+      },
+    };
+    this.notify(event);
   }
 }

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -19,6 +19,7 @@ export class CanvasViewModel extends Observable<any> {
 
   setState(state: ICanvasState) {
     this.state = state;
+    this.notifyStateChanged();
   }
 
   setShapeType(type: string) {
@@ -111,10 +112,11 @@ export class CanvasViewModel extends Observable<any> {
   }
 
   notifyStateChanged() {
-    const event: CanvasEvent<{ currentState: string }> = {
+    const event: CanvasEvent<{ currentState: string, drawingShape?: string }> = {
       type: "STATE_CHANGED",
       data: {
         currentState: this.state.constructor.name,
+        drawingShape: this.state instanceof DrawingState ? this.shapeType : undefined,
       },
     };
     this.notify(event);


### PR DESCRIPTION
## Shape 내부 클릭
목적: Shape의 `start`와 `end`로 이루어진 테두리가 아니라 Shape 자체 또는 바운더리를 클릭 시 선택되도록 한다.

### 구현
- Shape 인터페이스에 isPointInside 메서드 추가
- Rectangle, Ellipse, Line 클래스에서 isPointInside 메서드 구현
  - Rectangle: 사각형 내부 클릭 여부 확인
  - Ellipse: 타원의 방정식 기반 내부 클릭 여부 확인
  - Line: 직선의 방정식 + 박스 내 범위 확인
    - 박스 내 범위 확인만 하면 기존처럼 박스 클릭해도 선택됨
    - 점과 직선 사이 공식을 활용하여 거리를 구하고 허용 범주 내에 속하는지 확인
- CanvasState의 checkShapeClick 메서드에서 isPointInside 호출로 클릭 로직 단순화
- 각 Shape의 특성에 맞는 클릭 판정 로직 적용
### 기타...
- 내부 클릭 이후 **move할 때에도 내부 클릭 기준으로 해서 선 옮길 때 불편할 수 있을 것 같아 이 부분도 기능에 넣어둘게요**
- 선 클릭 인정 범위가 좁다면 수정 가능

![선내부클릭](https://github.com/user-attachments/assets/d699e523-e2c1-4232-bcaf-c71e6b3544cd)
_아니 내 gif은 왤케 꼬질하고 낡았어..._


## Notify 분리
목적: shapes, selectedShapes만 전달하던 notify의 역할을 확장한다.

### 구현
- `Observer`에 제네릭 타입을 추가하여 다양한 이벤트 데이터를 안전하게 처리할 수 있도록 개선했습니다.
- `Observable`에 `CanvasEvent` 타입을 정의하고, 이벤트의 `type`과 `data`에 따라 유연하게 확장 가능한 구조로 리팩토링했습니다.
- `viewModel`에서는 `SHAPES_UPDATED`, `STATE_CHANGED` 등 이벤트 타입별로 메서드를 분리해 가독성과 관리성을 높였습니다.
- `view`에서는 `useCanvasEvent` 훅을 통해 `eventType`을 확인하고, `data`의 key를 통해 구체적인 데이터를 받아 처리할 수 있도록 구현했습니다.
### 기타...
- useCanvasEvent 훅 사용이 어렵고 헷갈릴 수 있으니 언제든 질문 환영!!!

## Toolbar 버튼 활성화 및 리셋버튼 추가
목적: 현재 선택된 모드가 무엇인지 확인할 수 있도록 한다. 리셋 버튼을 통해 새로 그릴 수 있게 한다.

### 구현
- 위에서 분리한 notify 메서드를 활용하여 현재 viewModel의 `State`와 `shapeType`를 반환한다.
- 초기 설정은 `DrawingState`에 `Rectangle` 이므로 이를 프론트에서도 반영
- 리셋 버튼에도 이를 적용하여 shapes와 selectedShapes를 비우고 다시 default 설정으로 가게 함.
### 기타...
- 아무것도 아닌 상태를 만들지..? << 솔직히 후순위
