### PR TITLE
추상 클래스 도입 및 속성 처리 로직 분리

### DIFF
--- a/src/components/propertyRenderFactory.tsx
+++ b/src/components/propertyRenderFactory.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { ColorRenderer, DropdownRenderer, NumberRenderer, ReadOnlyRenderer, TextRenderer } from "./propertyRenderers";
+import { PROPERTY_TYPES } from "../constants";
+
+
+type RendererProps = {
+    name: string;
+    value: string | number;
+    onChange: (newValue: string | number) => void;
+};
+
+const rendererMap: Record<string, (props: RendererProps) => React.ReactNode> = {
+    [PROPERTY_TYPES.COLOR]: ({ name, value, onChange }) => (
+      <ColorRenderer name={name} value={value} onChange={onChange} />
+    ),
+    [PROPERTY_TYPES.TEXT]: ({ name, value, onChange }) => (
+      <TextRenderer name={name} value={value} onChange={onChange} />
+    ),
+    [PROPERTY_TYPES.NUMBER]: ({ name, value, onChange }) => (
+      <NumberRenderer name={name} value={value} onChange={onChange} />
+    ),
+    [PROPERTY_TYPES.DROPDOWN]: ({ name, value, onChange }) => (
+      <DropdownRenderer name={name} value={value} onChange={onChange} />
+    ),
+    [PROPERTY_TYPES.READ]: ({ name, value }) => (
+      <ReadOnlyRenderer name={name} value={value} onChange={() => {}} />
+    ),
+};
+  
+
+export class PropertyRendererFactory {
+    static createRenderer(
+        type: string,
+        name: string,
+        value: string | number,
+        onChange: (newValue: string | number) => void
+    ): React.ReactNode {
+        const renderer = rendererMap[type];
+        return renderer
+            ? renderer({ name, value, onChange })
+            : null;
+    }
+}

--- a/src/components/propertyRenderers.tsx
+++ b/src/components/propertyRenderers.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DROPDOWN_OPTIONS, NAME_TO_OPTION_KEY } from "../constants";
+import { DROPDOWN_OPTIONS } from "../constants";
 
 interface RendererProps {
   name: string;
@@ -41,8 +41,7 @@ export const NumberRenderer: React.FC<RendererProps> = ({ name, value, onChange 
 );
 
 export const DropdownRenderer: React.FC<RendererProps> = ({ name, value, onChange }) => {
-  const optionKey = NAME_TO_OPTION_KEY[name]; // name을 NameToOptionKey로 제한
-  const options = DROPDOWN_OPTIONS[optionKey] || [];
+  const options = DROPDOWN_OPTIONS[name] || [];
 
   return <div className="propertyItem" key={name}>
     <span>{name}:</span>

--- a/src/components/propertyRenderers.tsx
+++ b/src/components/propertyRenderers.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { DROPDOWN_OPTIONS, NAME_TO_OPTION_KEY } from "../constants";
+
+interface RendererProps {
+  name: string;
+  value: string | number;
+  onChange: (newValue: string | number) => void;
+}
+
+export const ColorRenderer: React.FC<RendererProps> = ({ name, value, onChange }) => (
+  <div className="propertyItem" key={name}>
+    <span>{name}:</span>
+    <input
+      type="color"
+      value={value as string}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  </div>
+);
+
+export const TextRenderer: React.FC<RendererProps> = ({ name, value, onChange }) => (
+  <div className="propertyItem" key={name}>
+    <span>{name}:</span>
+    <input
+      type="text"
+      value={value as string}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  </div>
+);
+
+export const NumberRenderer: React.FC<RendererProps> = ({ name, value, onChange }) => (
+  <div className="propertyItem" key={name}>
+    <span>{name}:</span>
+    <input
+      type="number"
+      value={value as number}
+      onChange={(e) => onChange(Number(e.target.value))}
+    />
+  </div>
+);
+
+export const DropdownRenderer: React.FC<RendererProps> = ({ name, value, onChange }) => {
+  const optionKey = NAME_TO_OPTION_KEY[name]; // name을 NameToOptionKey로 제한
+  const options = DROPDOWN_OPTIONS[optionKey] || [];
+
+  return <div className="propertyItem" key={name}>
+    <span>{name}:</span>
+    <select
+      value={value as string}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  </div>
+};
+
+export const ReadOnlyRenderer: React.FC<RendererProps> = ({ name, value }) => (
+  <div className="propertyItem" key={name}>
+    <span>{name}:</span>
+    <strong>{value}</strong>
+  </div>
+);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,45 @@
 export const CANVAS = {
-    WIDTH: 800,
-    HEIGHT: 600,
+  WIDTH: 800,
+  HEIGHT: 600,
 }
+
+export const DEFAULT_SHAPE = {
+  WIDTH: 200,
+  HEIGHT: 100,
+  FONT_SIZE: 30,
+}
+
+export const PROPERTY_NAMES = {
+  COLOR: "색",
+  TEXT: "텍스트",
+  FONT: "폰트",
+  FONT_SIZE: "글자 크기",
+  WIDTH: "너비",
+  HEIGHT: "높이",
+  HORIZONTAL_POS: "가로 위치",
+  VERTICAL_POS: "세로 위치",
+  LENGTH: "길이",
+  LINEWIDTH: "선 굵기",
+  SHADOW_ANGLE: "그림자 각도",
+  SHADOW_RADIUS: "그림자 간격",
+  SHADOW_BLUR: "그림자 흐리게",
+  SHADOW_COLOR: "그림자 색",
+  BORDER_WIDTH: "테두리 굵기",
+  BORDER_COLOR: "테두리 색",
+};
+
+export const PROPERTY_TYPES = {
+  COLOR: "color",
+  TEXT: "text",
+  NUMBER: "number",
+  DROPDOWN: "dropdown",
+  READ: "read",
+};
+
+export const DROPDOWN_OPTIONS: { [key: string]: string[] } = {
+  FONT: ["Arial", "Sans Serif"],
+};
+
+export const NAME_TO_OPTION_KEY: { [key: string]: string } = {
+  "폰트": "FONT",
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -37,9 +37,5 @@ export const PROPERTY_TYPES = {
 };
 
 export const DROPDOWN_OPTIONS: { [key: string]: string[] } = {
-  FONT: ["Arial", "Sans Serif"],
-};
-
-export const NAME_TO_OPTION_KEY: { [key: string]: string } = {
-  "폰트": "FONT",
+  [PROPERTY_NAMES.FONT]: ["Arial", "Sans Serif"],
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,4 @@
+export const CANVAS = {
+    WIDTH: 800,
+    HEIGHT: 600,
+}

--- a/src/entity/property/PropertyHandlers.ts
+++ b/src/entity/property/PropertyHandlers.ts
@@ -1,0 +1,96 @@
+import { PROPERTY_NAMES, PROPERTY_TYPES } from "../../constants";
+
+export interface Property {
+  type: string;
+  name: string;
+  value: string | number;
+}
+
+export interface PropertyHandler<T> {
+  type: string;
+  name: string;
+  getValue(shape: T): string | number;
+  setValue(shape: T, value: any): void;
+}
+
+export const CommonPropertyHandlers = {
+  HorizontalPos: <T extends { centerX: number; setCenterX(newX: number): void }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.HORIZONTAL_POS,
+    getValue: (shape) => Math.round(shape.centerX),
+    setValue: (shape, value) => shape.setCenterX(Number(value)),
+  }),
+  VerticalPos: <T extends { centerY: number; setCenterY(newY: number): void }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.VERTICAL_POS,
+    getValue: (shape) => Math.round(shape.centerY),
+    setValue: (shape, value) => shape.setCenterY(Number(value)),
+  }),
+  Width: <T extends { width: number; setWidth(newWidth: number): void }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.WIDTH,
+    getValue: (shape) => Math.round(shape.width),
+    setValue: (shape, value) => shape.setWidth(Number(value)),
+  }),
+  Height: <T extends { height: number; setHeight(newHeight: number): void }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.HEIGHT,
+    getValue: (shape) => Math.round(shape.height),
+    setValue: (shape, value) => shape.setHeight(Number(value)),
+  }),
+  Color: <T extends { color: string }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.COLOR,
+    name: PROPERTY_NAMES.COLOR,
+    getValue: (shape) => shape.color,
+    setValue: (shape, value) => { shape.color = value.toString(); },
+  }),
+  ShadowAngle: <T extends { shadowAngle: number; shadowRadius: number; shadowOffsetX: number; shadowOffsetY: number }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.SHADOW_ANGLE,
+    getValue: (shape) => Math.round(shape.shadowAngle * (180 / Math.PI)),
+    setValue: (shape, value) => {
+      const newAngle = Number(value) * (Math.PI / 180);
+      const radius = shape.shadowRadius;
+      shape.shadowOffsetX = radius * Math.cos(newAngle);
+      shape.shadowOffsetY = radius * Math.sin(newAngle);
+    },
+  }),
+  ShadowRadius: <T extends { shadowRadius: number; shadowAngle: number; shadowOffsetX: number; shadowOffsetY: number }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.SHADOW_RADIUS,
+    getValue: (shape) => shape.shadowRadius,
+    setValue: (shape, value) => {
+      const newRadius = Number(value);
+      const shadowAngle = shape.shadowAngle;
+      shape.shadowOffsetX = newRadius * Math.cos(shadowAngle);
+      shape.shadowOffsetY = newRadius * Math.sin(shadowAngle);
+    },
+  }),
+  ShadowBlur: <T extends { shadowBlur: number }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.SHADOW_BLUR,
+    getValue: (shape) => shape.shadowBlur,
+    setValue: (shape, value) => { shape.shadowBlur = Number(value); },
+  }),
+  ShadowColor: <T extends { shadowColor: string }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.COLOR,
+    name: PROPERTY_NAMES.SHADOW_COLOR,
+    getValue: (shape) => shape.shadowColor,
+    setValue: (shape, value) => { shape.shadowColor = value.toString(); },
+  }),
+};
+
+export const BorderedShapePropertyHandlers = {
+  BorderWidth: <T extends { borderWidth: number }>() => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.BORDER_WIDTH,
+    getValue: (shape: T) => Math.round(shape.borderWidth),
+    setValue: (shape: T, value: any) => { shape.borderWidth = Number(value); },
+  }),
+  BorderColor: <T extends { borderColor: string }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.COLOR,
+    name: PROPERTY_NAMES.BORDER_COLOR,
+    getValue: (shape) => shape.borderColor,
+    setValue: (shape, value) => { shape.borderColor = value.toString(); },
+  }),
+};

--- a/src/entity/shape/Ellipse.ts
+++ b/src/entity/shape/Ellipse.ts
@@ -100,6 +100,7 @@ export class Ellipse extends AbstractShape {
           CommonPropertyHandlers.VerticalPos(),
           Ellipse.WidthHandler(),
           Ellipse.HeightHandler(),
+          CommonPropertyHandlers.Color(),
           CommonPropertyHandlers.ShadowAngle(),
           CommonPropertyHandlers.ShadowRadius(),
           CommonPropertyHandlers.ShadowBlur(),

--- a/src/entity/shape/Ellipse.ts
+++ b/src/entity/shape/Ellipse.ts
@@ -1,30 +1,20 @@
-import { Shape, Property } from "./Shape";
+import { PROPERTY_NAMES, PROPERTY_TYPES } from "../../constants";
+import { BorderedShapePropertyHandlers, CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import { AbstractShape } from "./Shape";
 
-export class Ellipse implements Shape {
+export class Ellipse extends AbstractShape {
+  constructor(
+    id: number,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    color?: string
+  ) {
+      super(id, startX, startY, endX, endY, color);
+  }
   private borderWidth: number = 0;
   private borderColor: string = "#000000";
-  private color: string = "#000000";
-
-  private shadowColor: string = "#000000";
-  private shadowOffsetX: number = 0;
-  private shadowOffsetY: number = 0;
-  private shadowBlur: number = 0;
-
-  constructor(
-    public id: number,
-    public startX: number,
-    public startY: number,
-    public endX: number,
-    public endY: number
-  ) {}
-
-  get centerX(): number {
-    return (this.endX + this.startX) / 2;
-  }
-
-  get centerY(): number {
-    return (this.endY + this.startY) / 2;
-  }
 
   get radiusX(): number {
     return Math.abs(this.endX - this.startX) / 2;
@@ -32,19 +22,6 @@ export class Ellipse implements Shape {
 
   get radiusY(): number {
     return Math.abs(this.endY - this.startY) / 2;
-  }
-
-  get shadowAngle(): number {
-    return Math.atan2(this.shadowOffsetY, this.shadowOffsetX);
-  }
-
-  get shadowRadius(): number {
-    return Math.round(
-      Math.sqrt(
-        this.shadowOffsetX * this.shadowOffsetX +
-          this.shadowOffsetY * this.shadowOffsetY
-      )
-    );
   }
 
   draw(ctx: CanvasRenderingContext2D) {
@@ -82,49 +59,6 @@ export class Ellipse implements Shape {
     }
   }
 
-  setShadow(ctx: CanvasRenderingContext2D): void {
-    ctx.shadowColor = this.shadowColor;
-    ctx.shadowOffsetX = this.shadowOffsetX;
-    ctx.shadowOffsetY = this.shadowOffsetY;
-    ctx.shadowBlur = this.shadowBlur;
-  }
-
-  move(dx: number, dy: number): void {
-    this.startX += dx;
-    this.startY += dy;
-    this.endX += dx;
-    this.endY += dy;
-  }
-  getResizeHandles(): { x: number; y: number; pos: string }[] {
-    return [
-      { x: this.startX - 5, y: this.startY - 5, pos: "top-left" }, // top-left
-      { x: this.endX - 5, y: this.startY - 5, pos: "top-right" }, // top-right
-      { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" }, // bottom-right
-      { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" }, // bottom-left
-    ];
-  }
-
-  resize(dx: number, dy: number, pos: string): void {
-    switch (pos) {
-      case "top-left":
-        this.startX += dx;
-        this.startY += dy;
-        break;
-      case "top-right":
-        this.endX += dx;
-        this.startY += dy;
-        break;
-      case "bottom-right":
-        this.endX += dx;
-        this.endY += dy;
-        break;
-      case "bottom-left":
-        this.startX += dx;
-        this.endY += dy;
-        break;
-    }
-  }
-
   isPointInside(x: number, y: number): boolean {
     const centerX = this.centerX;
     const centerY = this.centerY;
@@ -139,87 +73,39 @@ export class Ellipse implements Shape {
     );
   }
 
-  getProperties(): Property[] {
-    return [
-      {
-        name: "가로 위치",
-        value: this.centerX,
-        editable: true,
-      },
-      {
-        name: "세로 위치",
-        value: this.centerY,
-        editable: true,
-      },
-      { name: "높이", value: Math.abs(this.radiusY * 2), editable: true },
-      { name: "너비", value: Math.abs(this.radiusX * 2), editable: true },
-      { name: "색", value: this.color, editable: true },
-      { name: "테두리 굵기", value: this.borderWidth, editable: true },
-      { name: "테두리 색", value: this.borderColor, editable: true },
-      {
-        name: "그림자 각도",
-        value: Math.round(this.shadowAngle * (180 / Math.PI)),
-        editable: true,
-      },
-      { name: "그림자 간격", value: this.shadowRadius, editable: true },
-      { name: "그림자 흐리게", value: this.shadowBlur, editable: true },
-      { name: "그림자 색", value: this.shadowColor, editable: true },
-    ];
-  }
-
-  setProperties(name: string, value: number): void {
-    switch (name) {
-      case "가로 위치":
-        const newX = Number(value);
-        const width = this.radiusX;
-        this.startX = newX - width;
-        this.endX = newX + width;
-        break;
-      case "세로 위치":
-        const newY = Number(value);
-        const height = this.radiusY;
-        this.startY = newY - height;
-        this.endY = newY + height;
-        break;
-      case "높이":
-        const centerY = this.centerY;
-        this.startY = centerY - Number(value) / 2;
-        this.endY = centerY + Number(value) / 2;
-        break;
-      case "너비":
-        const centerX = this.centerX;
-        this.startX = centerX - Number(value) / 2;
-        this.endX = centerX + Number(value) / 2;
-        break;
-      case "색":
-        this.color = value.toString();
-        break;
-      case "테두리 굵기":
-        this.borderWidth = Number(value);
-        break;
-      case "테두리 색":
-        this.borderColor = value.toString();
-        break;
-      case "그림자 색":
-        this.shadowColor = value.toString();
-        break;
-      case "그림자 각도":
-        const newAngle = Number(value) * (Math.PI / 180);
-        const radius = this.shadowRadius;
-        this.shadowOffsetX = radius * Math.cos(newAngle);
-        this.shadowOffsetY = radius * Math.sin(newAngle);
-        break;
-      case "그림자 간격":
-        const newRadius = Number(value);
-        const angle = this.shadowAngle;
-        this.shadowOffsetX = newRadius * Math.cos(angle);
-        this.shadowOffsetY = newRadius * Math.sin(angle);
-        break;
-      case "그림자 흐리게":
-        this.shadowBlur = Number(value);
-        break;
-      default:
-        throw new Error("Invalid property name");
+  // 사용할 속성 골라넣기
+  private static WidthHandler = (): PropertyHandler<Ellipse> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.WIDTH,
+    getValue: (shape) => Math.abs(shape.radiusX * 2),
+    setValue: (shape, value) => {
+      const centerX = shape.centerX;
+      shape.startX = centerX - Number(value) / 2;
+      shape.endX = centerX + Number(value) / 2;
     }
+  });
+  private static HeightHandler = (): PropertyHandler<Ellipse> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.HEIGHT,
+    getValue: (shape) => Math.abs(shape.radiusY * 2),
+    setValue: (shape, value) => {
+      const centerY = shape.centerY;
+      shape.startY = centerY - Number(value) / 2;
+      shape.endY = centerY + Number(value) / 2;
+    }
+  });
+  protected getPropertyHandlers(): PropertyHandler<this>[] {
+      return [
+          CommonPropertyHandlers.HorizontalPos(),
+          CommonPropertyHandlers.VerticalPos(),
+          Ellipse.WidthHandler(),
+          Ellipse.HeightHandler(),
+          CommonPropertyHandlers.ShadowAngle(),
+          CommonPropertyHandlers.ShadowRadius(),
+          CommonPropertyHandlers.ShadowBlur(),
+          CommonPropertyHandlers.ShadowColor(),
+          BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>(),
+          BorderedShapePropertyHandlers.BorderColor<this & { borderColor: string }>(),
+      ];
   }
 }

--- a/src/entity/shape/ImageShape.ts
+++ b/src/entity/shape/ImageShape.ts
@@ -1,53 +1,22 @@
-import { Shape, Property } from "./Shape";
+import { BorderedShapePropertyHandlers, CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import { AbstractShape } from "./Shape";
 
-export class ImageShape implements Shape {
+export class ImageShape extends AbstractShape {
+  constructor(
+    id: number,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    public imageUrl: string,
+    color?: string,
+  ) {
+      super(id, startX, startY, endX, endY, color);
+  }
   private borderWidth: number = 0;
   private borderColor: string = "#000000";
 
-  private shadowColor: string = "#000000";
-  private shadowOffsetX: number = 0;
-  private shadowOffsetY: number = 0;
-  private shadowBlur: number = 0;
-
-  constructor(
-    public id: number,
-    public startX: number,
-    public startY: number,
-    public endX: number,
-    public endY: number,
-    public imageUrl: string
-  ) {}
-
   private imageElement: HTMLImageElement | null = null;
-
-  get width(): number {
-    return this.endX - this.startX;
-  }
-
-  get height(): number {
-    return this.endY - this.startY;
-  }
-
-  get centerX(): number {
-    return (this.endX + this.startX) / 2;
-  }
-
-  get centerY(): number {
-    return (this.endY + this.startY) / 2;
-  }
-
-  get shadowAngle(): number {
-    return Math.atan2(this.shadowOffsetY, this.shadowOffsetX);
-  }
-
-  get shadowRadius(): number {
-    return Math.round(
-      Math.sqrt(
-        this.shadowOffsetX * this.shadowOffsetX +
-          this.shadowOffsetY * this.shadowOffsetY
-      )
-    );
-  }
 
   draw(ctx: CanvasRenderingContext2D | null): void {
     if (!ctx) throw new Error("context is null");
@@ -83,50 +52,6 @@ export class ImageShape implements Shape {
     }
   }
 
-  setShadow(ctx: CanvasRenderingContext2D): void {
-    ctx.shadowColor = this.shadowColor;
-    ctx.shadowOffsetX = this.shadowOffsetX;
-    ctx.shadowOffsetY = this.shadowOffsetY;
-    ctx.shadowBlur = this.shadowBlur;
-  }
-
-  move(dx: number, dy: number): void {
-    this.startX += dx;
-    this.startY += dy;
-    this.endX += dx;
-    this.endY += dy;
-  }
-
-  getResizeHandles(): { x: number; y: number; pos: string }[] {
-    return [
-      { x: this.startX - 5, y: this.startY - 5, pos: "top-left" },
-      { x: this.endX - 5, y: this.startY - 5, pos: "top-right" },
-      { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" },
-      { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" },
-    ];
-  }
-
-  resize(dx: number, dy: number, pos: string): void {
-    switch (pos) {
-      case "top-left":
-        this.startX += dx;
-        this.startY += dy;
-        break;
-      case "top-right":
-        this.endX += dx;
-        this.startY += dy;
-        break;
-      case "bottom-right":
-        this.endX += dx;
-        this.endY += dy;
-        break;
-      case "bottom-left":
-        this.startX += dx;
-        this.endY += dy;
-        break;
-    }
-  }
-
   isPointInside(x: number, y: number): boolean {
     return (
       x >= Math.min(this.startX, this.endX) &&
@@ -136,83 +61,20 @@ export class ImageShape implements Shape {
     );
   }
 
-  getProperties(): Property[] {
-    return [
-      {
-        name: "가로 위치",
-        value: this.centerX,
-        editable: true,
-      },
-      {
-        name: "세로 위치",
-        value: this.centerY,
-        editable: true,
-      },
-      { name: "높이", value: Math.abs(this.height), editable: true },
-      { name: "너비", value: Math.abs(this.width), editable: true },
-      { name: "테두리 굵기", value: this.borderWidth, editable: true },
-      { name: "테두리 색", value: this.borderColor, editable: true },
-      {
-        name: "그림자 각도",
-        value: Math.round(this.shadowAngle * (180 / Math.PI)),
-        editable: true,
-      },
-      { name: "그림자 간격", value: this.shadowRadius, editable: true },
-      { name: "그림자 흐리게", value: this.shadowBlur, editable: true },
-      { name: "그림자 색", value: this.shadowColor, editable: true },
-    ];
-  }
 
-  setProperties(name: string, value: any): void {
-    switch (name) {
-      case "가로 위치":
-        const newX = Number(value);
-        const width = this.width;
-        this.startX = newX - width / 2;
-        this.endX = newX + width / 2;
-        break;
-      case "세로 위치":
-        const newY = Number(value);
-        const height = this.height;
-        this.startY = newY - height / 2;
-        this.endY = newY + height / 2;
-        break;
-      case "높이":
-        const centerY = this.centerY;
-        this.startY = centerY - Number(value) / 2;
-        this.endY = centerY + Number(value) / 2;
-        break;
-      case "너비":
-        const centerX = this.centerX;
-        this.startX = centerX - Number(value) / 2;
-        this.endX = centerX + Number(value) / 2;
-        break;
-      case "테두리 굵기":
-        this.borderWidth = Number(value);
-        break;
-      case "테두리 색":
-        this.borderColor = value.toString();
-        break;
-      case "그림자 색":
-        this.shadowColor = value.toString();
-        break;
-      case "그림자 각도":
-        const newAngle = Number(value) * (Math.PI / 180);
-        const radius = this.shadowRadius;
-        this.shadowOffsetX = radius * Math.cos(newAngle);
-        this.shadowOffsetY = radius * Math.sin(newAngle);
-        break;
-      case "그림자 간격":
-        const newRadius = Number(value);
-        const angle = this.shadowAngle;
-        this.shadowOffsetX = newRadius * Math.cos(angle);
-        this.shadowOffsetY = newRadius * Math.sin(angle);
-        break;
-      case "그림자 흐리게":
-        this.shadowBlur = Number(value);
-        break;
-      default:
-        throw new Error("Invalid property name");
-    }
+  protected getPropertyHandlers(): PropertyHandler<this>[] {
+    return [
+        CommonPropertyHandlers.HorizontalPos(),
+        CommonPropertyHandlers.VerticalPos(),
+        CommonPropertyHandlers.Width(),
+        CommonPropertyHandlers.Height(),
+        CommonPropertyHandlers.Color(),
+        CommonPropertyHandlers.ShadowAngle(),
+        CommonPropertyHandlers.ShadowRadius(),
+        CommonPropertyHandlers.ShadowBlur(),
+        CommonPropertyHandlers.ShadowColor(),
+        BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>(),
+        BorderedShapePropertyHandlers.BorderColor<this & { borderColor: string }>(),
+    ];
   }
 }

--- a/src/entity/shape/Rectangle.ts
+++ b/src/entity/shape/Rectangle.ts
@@ -1,51 +1,19 @@
-import { Shape, Property } from "./Shape";
+import { BorderedShapePropertyHandlers, CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import { AbstractShape } from "./Shape";
 
-export class Rectangle implements Shape {
-  private borderWidth: number = 0;
-  private borderColor: string = "#000000";
-  private color: string = "#000000";
-
-  private shadowColor: string = "#000000";
-  private shadowOffsetX: number = 0;
-  private shadowOffsetY: number = 0;
-  private shadowBlur: number = 0;
-
+export class Rectangle extends AbstractShape {
   constructor(
-    public id: number,
-    public startX: number,
-    public startY: number,
-    public endX: number,
-    public endY: number
-  ) {}
-
-  get width(): number {
-    return this.endX - this.startX;
+    id: number,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    color?: string
+  ) {
+      super(id, startX, startY, endX, endY, color);
   }
-
-  get height(): number {
-    return this.endY - this.startY;
-  }
-
-  get centerX(): number {
-    return (this.endX + this.startX) / 2;
-  }
-
-  get centerY(): number {
-    return (this.endY + this.startY) / 2;
-  }
-
-  get shadowAngle(): number {
-    return Math.atan2(this.shadowOffsetY, this.shadowOffsetX);
-  }
-
-  get shadowRadius(): number {
-    return Math.round(
-      Math.sqrt(
-        this.shadowOffsetX * this.shadowOffsetX +
-          this.shadowOffsetY * this.shadowOffsetY
-      )
-    );
-  }
+  borderWidth: number = 0;
+  borderColor: string = "#000000";
 
   draw(ctx: CanvasRenderingContext2D) {
     if (!ctx) throw new Error("context is null");
@@ -61,51 +29,6 @@ export class Rectangle implements Shape {
       ctx.strokeRect(this.startX, this.startY, this.width, this.height);
     }
   }
-
-  setShadow(ctx: CanvasRenderingContext2D): void {
-    ctx.shadowColor = this.shadowColor;
-    ctx.shadowOffsetX = this.shadowOffsetX;
-    ctx.shadowOffsetY = this.shadowOffsetY;
-    ctx.shadowBlur = this.shadowBlur;
-  }
-
-  move(dx: number, dy: number): void {
-    this.startX += dx;
-    this.startY += dy;
-    this.endX += dx;
-    this.endY += dy;
-  }
-
-  getResizeHandles(): { x: number; y: number; pos: string }[] {
-    return [
-      { x: this.startX - 5, y: this.startY - 5, pos: "top-left" }, // top-left
-      { x: this.endX - 5, y: this.startY - 5, pos: "top-right" }, // top-right
-      { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" }, // bottom-right
-      { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" }, // bottom-left
-    ];
-  }
-
-  resize(dx: number, dy: number, pos: string): void {
-    switch (pos) {
-      case "top-left":
-        this.startX += dx;
-        this.startY += dy;
-        break;
-      case "top-right":
-        this.endX += dx;
-        this.startY += dy;
-        break;
-      case "bottom-right":
-        this.endX += dx;
-        this.endY += dy;
-        break;
-      case "bottom-left":
-        this.startX += dx;
-        this.endY += dy;
-        break;
-    }
-  }
-
   isPointInside(x: number, y: number): boolean {
     return (
       x >= Math.min(this.startX, this.endX) &&
@@ -115,88 +38,19 @@ export class Rectangle implements Shape {
     );
   }
 
-  getProperties(): Property[] {
+  protected getPropertyHandlers(): PropertyHandler<this>[] {
     return [
-      {
-        name: "가로 위치",
-        value: this.centerX,
-        editable: true,
-      },
-      {
-        name: "세로 위치",
-        value: this.centerY,
-        editable: true,
-      },
-      { name: "높이", value: Math.abs(this.height), editable: true },
-      { name: "너비", value: Math.abs(this.width), editable: true },
-      { name: "색", value: this.color, editable: true },
-      { name: "테두리 굵기", value: this.borderWidth, editable: true },
-      { name: "테두리 색", value: this.borderColor, editable: true },
-      {
-        name: "그림자 각도",
-        value: Math.round(this.shadowAngle * (180 / Math.PI)),
-        editable: true,
-      },
-      { name: "그림자 간격", value: this.shadowRadius, editable: true },
-      { name: "그림자 흐리게", value: this.shadowBlur, editable: true },
-      { name: "그림자 색", value: this.shadowColor, editable: true },
+        CommonPropertyHandlers.HorizontalPos(),
+        CommonPropertyHandlers.VerticalPos(),
+        CommonPropertyHandlers.Width(),
+        CommonPropertyHandlers.Height(),
+        CommonPropertyHandlers.Color(),
+        CommonPropertyHandlers.ShadowAngle(),
+        CommonPropertyHandlers.ShadowRadius(),
+        CommonPropertyHandlers.ShadowBlur(),
+        CommonPropertyHandlers.ShadowColor(),
+        BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>(),
+        BorderedShapePropertyHandlers.BorderColor<this & { borderColor: string }>(),
     ];
-  }
-
-  setProperties(name: string, value: any): void {
-    switch (name) {
-      case "가로 위치":
-        const newX = Number(value);
-        const width = this.width;
-        this.startX = newX - width / 2;
-        this.endX = newX + width / 2;
-        break;
-      case "세로 위치":
-        const newY = Number(value);
-        const height = this.height;
-        this.startY = newY - height / 2;
-        this.endY = newY + height / 2;
-        break;
-      case "높이":
-        const centerY = this.centerY;
-        this.startY = centerY - Number(value) / 2;
-        this.endY = centerY + Number(value) / 2;
-        break;
-      case "너비":
-        const centerX = this.centerX;
-        this.startX = centerX - Number(value) / 2;
-        this.endX = centerX + Number(value) / 2;
-        break;
-      case "색":
-        this.color = value.toString();
-        break;
-      case "테두리 굵기":
-        this.borderWidth = Number(value);
-        break;
-      case "테두리 색":
-        this.borderColor = value.toString();
-        break;
-      case "그림자 색":
-        this.shadowColor = value.toString();
-        break;
-      case "그림자 각도":
-        const newAngle = Number(value) * (Math.PI / 180);
-        const radius = this.shadowRadius;
-        this.shadowOffsetX = radius * Math.cos(newAngle);
-        this.shadowOffsetY = radius * Math.sin(newAngle);
-        break;
-      case "그림자 간격":
-        const newRadius = Number(value);
-        const angle = this.shadowAngle;
-        this.shadowOffsetX = newRadius * Math.cos(angle);
-        this.shadowOffsetY = newRadius * Math.sin(angle);
-        break;
-      case "그림자 흐리게":
-        this.shadowBlur = Number(value);
-        break;
-
-      default:
-        throw new Error("Invalid property name");
-    }
   }
 }

--- a/src/entity/shape/Shape.ts
+++ b/src/entity/shape/Shape.ts
@@ -1,20 +1,148 @@
+import { Property, PropertyHandler } from "../property/PropertyHandlers";
+
 export interface Shape {
   id: number;
   startX: number;
   startY: number;
   endX: number;
   endY: number;
+  color: string;
+  readonly width: number;
+  readonly height: number;
+  readonly centerX: number;
+  readonly centerY: number;
+
   draw(ctx: CanvasRenderingContext2D | null): void;
   move(dx: number, dy: number): void;
+  setShadow(ctx: CanvasRenderingContext2D): void;
   getResizeHandles(): { x: number; y: number; pos: string }[];
   resize(dx: number, dy: number, pos: string): void;
   isPointInside(x: number, y: number): boolean;
   getProperties(): Property[];
-  setProperties(name: string, value: number): void;
+  setProperties(name: string, value: any): void;
 }
 
-export interface Property {
-  name: string;
-  value: string | number;
-  editable: boolean;
+export abstract class AbstractShape implements Shape {
+  constructor(
+      public id: number,
+      public startX: number,
+      public startY: number,
+      public endX: number,
+      public endY: number,
+      public color: string = "#000000",
+  ) {}
+  shadowColor: string = "#000000";
+  shadowOffsetX: number = 0;
+  shadowOffsetY: number = 0;
+  shadowBlur: number = 0;
+
+  get width(): number {
+      return Math.abs(this.endX - this.startX);
+  }
+  get height(): number {
+      return Math.abs(this.endY - this.startY);
+  }
+  get centerX(): number {
+      return (this.startX + this.endX) / 2
+  }
+  get centerY(): number {
+      return (this.startY + this.endY) / 2
+  }
+  get shadowAngle(): number {
+    return Math.atan2(this.shadowOffsetY, this.shadowOffsetX);
+  }
+  get shadowRadius(): number {
+    return Math.round(
+      Math.sqrt(
+        this.shadowOffsetX * this.shadowOffsetX +
+          this.shadowOffsetY * this.shadowOffsetY
+      )
+    );
+  }
+
+  move(dx: number, dy: number): void {
+      this.startX += dx;
+      this.startY += dy;
+      this.endX += dx;
+      this.endY += dy;
+  }
+  
+  setShadow(ctx: CanvasRenderingContext2D): void {
+    ctx.shadowColor = this.shadowColor;
+    ctx.shadowOffsetX = this.shadowOffsetX;
+    ctx.shadowOffsetY = this.shadowOffsetY;
+    ctx.shadowBlur = this.shadowBlur;
+  }
+
+  // 4개 꼭지점 기준
+  // Line은 override 필요
+  getResizeHandles(): { x: number; y: number; pos: string; }[] {
+      return [
+          { x: this.startX - 5, y: this.startY - 5, pos: "top-left" },
+          { x: this.endX - 5, y: this.startY - 5, pos: "top-right" },
+          { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" },
+          { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" },
+      ];
+  }
+  // Line은 override 필요
+  resize(dx: number, dy: number, pos: string): void {
+      switch (pos) {
+          case "top-left":
+            this.startX += dx;
+            this.startY += dy;
+            break;
+          case "top-right":
+            this.endX += dx;
+            this.startY += dy;
+            break;
+          case "bottom-right":
+            this.endX += dx;
+            this.endY += dy;
+            break;
+          case "bottom-left":
+            this.startX += dx;
+            this.endY += dy;
+            break;
+        }
+  }
+
+  abstract draw(ctx: CanvasRenderingContext2D): void;
+  abstract isPointInside(x: number, y: number): boolean;
+  // 혹시나 getProperties와 헷갈려서 밖에서 사용할까봐 protected로 구현
+  protected abstract getPropertyHandlers(): PropertyHandler<this>[];
+
+  getProperties(): Property[] {
+      return this.getPropertyHandlers().map(handler => ({
+          type: handler.type,
+          name: handler.name,
+          value: handler.getValue(this),
+      }));
+  }
+
+  setProperties(name: string, value: any): void {
+      const handler = this.getPropertyHandlers().find(h => h.name === name);
+      if (!handler) throw new Error(`Invalid property name: ${name}`);
+      handler.setValue(this, value);
+  }
+
+  setCenterX(newX: number): void {
+      const width = this.width;
+      this.startX = newX - width / 2;
+      this.endX = newX + width / 2;
+  }
+  setCenterY(newY: number): void {
+      const height = this.height;
+      this.startY = newY - height / 2;
+      this.endY = newY + height / 2;
+  }
+  setWidth(newWidth: number): void {
+      const centerX = this.centerX;
+      this.startX = centerX - newWidth / 2;
+      this.endX = centerX + newWidth / 2;
+  }
+  setHeight(newHeight: number): void {
+      const centerY = this.centerY;
+      this.startY = centerY - newHeight / 2;
+      this.endY = centerY + newHeight / 2;
+  }
 }

--- a/src/view/Canvas.tsx
+++ b/src/view/Canvas.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { CanvasViewModel } from "../viewModel/CanvasViewModel";
 import { Shape } from "../entity/shape/Shape";
 import useCanvasEvent from "../hooks/useCanvasEvent";
+import { CANVAS } from "../constants";
 
 const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -37,8 +38,8 @@ const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
   return (
     <canvas
       ref={canvasRef}
-      width={800}
-      height={600}
+      width={CANVAS.WIDTH}
+      height={CANVAS.HEIGHT}
       onMouseDown={viewModel.handleMouseDown}
       onMouseMove={viewModel.handleMouseMove}
       onMouseUp={viewModel.handleMouseUp}

--- a/src/view/PropertyWindow.tsx
+++ b/src/view/PropertyWindow.tsx
@@ -3,6 +3,7 @@ import { Shape } from "../entity/shape/Shape"; // Shape 인터페이스 또는 �
 import { CanvasViewModel } from "../viewModel/CanvasViewModel";
 import useCanvasEvent from "../hooks/useCanvasEvent";
 import "./PropertyWindow.css";
+import { PropertyRendererFactory } from "../components/propertyRenderFactory";
 
 const PropertyWindow: React.FC<{ viewModel: CanvasViewModel }> = ({
   viewModel,
@@ -35,58 +36,18 @@ const PropertyWindow: React.FC<{ viewModel: CanvasViewModel }> = ({
         </div>
         <div className="property">
           {selectedShapes[0].getProperties().map((property) => {
-            if (
-              property.name === "색" ||
-              property.name === "테두리 색" ||
-              property.name === "그림자 색"
-            ) {
-              return (
-                <div key={property.name} className="propertyItem">
-                  <span>{property.name}:</span>{" "}
-                  <input
-                    type="color"
-                    value={property.value}
-                    onChange={(e) => {
-                      const newValue = e.target.value;
-                      viewModel.requestSetProperty(
-                        selectedShapes[0].id,
-                        property.name,
-                        newValue
-                      );
-                    }}
-                  />
-                  <br />
-                </div>
-              );
-            }
-            if (property.editable) {
-              return (
-                <div key={property.name} className="propertyItem">
-                  <span>{property.name}:</span>{" "}
-                  <input
-                    type="number"
-                    value={property.value}
-                    onChange={(e) => {
-                      const newValue = e.target.value;
-                      viewModel.requestSetProperty(
-                        selectedShapes[0].id,
-                        property.name,
-                        newValue
-                      );
-                    }}
-                  />
-                  <br />
-                </div>
-              );
-            } else {
-              return (
-                <div key={property.name} className="propertyItem">
-                  <span>{property.name}:</span>{" "}
-                  <strong>{property.value}</strong>
-                  <br />
-                </div>
-              );
-            }
+            return PropertyRendererFactory.createRenderer(
+              property.type,
+              property.name,
+              property.value,
+              (newValue) => {
+                viewModel.requestSetProperty(
+                  selectedShapes[0].id,
+                  property.name,
+                  newValue
+                );
+              }
+            );
           })}
         </div>
         <button


### PR DESCRIPTION
안녕하세요... 대공사 진행했어요... ~미리 죄송합니다~... 엄청나게 많은 변화가 일어났습니다...

## 추상화 클래스 도입
`Shape` 인터페이스를 구현하는 개별 모양들(`Rectangle`, `Line `등등)에서 비슷한 코드(`move`, `resize `등)가 반복되고 있었습니다.
중복되는 코드를 한 곳에 모아 `AbstractShape`라는 추상화 클래스를 만들었습니다.

개별화가 필요한 `draw`, `isPointInside `등은 abstract로 짜놔서 구체적인 일부 단계는 하위 클래스에서 구현하도록 강제했습니다.
또, 여러 객체 중에서 `Line`만 핸들이 2개라서 일단은 핸들 관련을 `AbstractShape`에 공통 메서드로 짜놓고 `Line`에서 `override`해서 커스터마이즈해줬어요!

<br/>



## 속성 처리 로직 분리 : `PropertyHandler.ts` 참고
사실 이 모든 일은 Text 객체를 만들다가 속성 창에 폰트(텍스트, 드랍다운 등...)를 입력할 수가 없어서 그거 뜯어 고치다가 일이 커졌습니다.
(약간 집 꾸미다가 갑자기 집 리모델링해버린 느낌...)
암튼 이 과정에서 "가로 위치" 와 같은 한글 속성을 모두 전역 상수화했습니다!

<br/>

### `PropertyHandler`란?
개별 속성(예: "가로 위치", "너비", "색")을 가져오고 설정하는 방법을 정의하는 객체의 타입을 만듭니다.
이 객체는 속성의 이름, 타입, 그리고 실제 값을 가져오고(`getValue`) 설정하는(`setValue`) 함수를 가집니다.


<br/>

### 공통 속성 핸들러
이 핸들러도 겹치는 항목이 많았습니다. 그런데, 모두가 일치하지는 않아서 일단 공통적으로 나오는 애들을 이곳에 넣어두고 개별 객체 안에서 **골라서** 쓸 수 있도록 했습니다!
어디다가 고르냐? 바로바로 `getPropertyHandlers`에 넣어주시면 됩니다요
```typescript
getPropertyHandlers(): PropertyHandler<this>[] {
    return [
        CommonPropertyHandlers.HorizontalPos(),
        CommonPropertyHandlers.VerticalPos(),
        Line.LengthHandler(),
        Line.LineWidthHandler(),
        CommonPropertyHandlers.Color(),
        CommonPropertyHandlers.ShadowAngle(),
        CommonPropertyHandlers.ShadowRadius(),
        CommonPropertyHandlers.ShadowBlur(),
        CommonPropertyHandlers.ShadowColor(),
    ];
  }
```
아 근데 여기보시면 `Line.LengthHandler()` 이렇게 되어있죠? 이거는 Line 객체에서만 사용되는 Handler라서 Line 내부에 구현해주었습니다.

두 개 이상에서 사용되지만 전체에서는 쓰지 않는 애들은 Common 말고 특성 이름을 따와서 `BorderedShapePropertyHandlers` 이런 식으로 따로 마련해주었어요.
<br/>
### 공통적이지 않은 속성에 대하여 PropertyHandler를 설정하는 과정...
`AbstractShape`는 모든 도형들의 공통 조상 클래스입니다. 이 클래스는 도형들이 기본적으로 가져야 할 속성이나 동작들을 정의하고 있지만, 모든 도형이 `borderWidth`나 `borderColor`와 같은 속성을 필요로 하지는 않기 때문에, 이러한 속성들은 `AbstractShape`에 포함되어 있지 않습니다.

그런데 `PropertyHandler`라는 구조는 일반적인 도형을 대상으로 속성을 처리하는 기능을 제공하고 있습니다. 이때, `PropertyHandler`가 기대하는 대상 타입은 `AbstractShape`이기 때문에, 거기에는 존재하지 않는 `borderWidth`나 `borderColor `속성에 접근하려고 하면 타입스크립트가 오류를 발생시킵니다 'borderWidth? 너가 준 타입에는 없는데?'라고 하는거죠

이를 해결하기 위해 `this & { borderWidth: number }`와 같은 타입 확장을 사용합니다. 이 문법은 "나는 기본적으로 this이지만, 거기에 추가적으로 `borderWidth`라는 속성도 있어요"라고 ts에게 명시적으로 알려주는 역할을 해요! 이렇게 하면 해당 속성이 `AbstractShape`에 명시되어 있지 않더라도, 특정 상황에서는 안전하게 사용할 수 있게 됩니다.
<br/>
결과적으로, 아래처럼 사용하게 됩니다.
```typescript
BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>()
```
`this`가 단순히 `AbstractShape`가 아니라, 실제로 `borderWidth` 속성을 가진 타입임을 명확히 전달하여, 타입 오류 없이 핸들러를 적용할 수 있도록 도와주는 방식입니다.

<br/>

이쯤에서 들었던 의문... 아니 나는 `Rectangle` 안에서 `this`로 쓴건데 왜 얘가 가지고 있는 속성을 인식을 못해?

![image](https://github.com/user-attachments/assets/1d857742-c23d-4085-a787-50967dbf52ec)

> this는 "현재 클래스 인스턴스"를 의미는 하지만, 해당 메서드 안에서 this 타입을 완전히 정적 분석해서 borderWidth와 같은 프로퍼티가 있다고 추론하지는 못할 수 있습니다. 특히 BorderedShapePropertyHandlers.BorderWidth<T>()가 제너릭 타입을 받고 그 안에서 T['borderWidth'] 같은 접근을 한다면, 타입스크립트는 이걸 명확히 보장하지 못하기 때문에 오류를 발생시킵니다.
> 
> 그래서 타입을 this & { borderWidth: number }처럼 확장해주는 것은 타입스크립트에게 “진짜야, 나 이 속성 있어”라고 확실히 알려주는 것입니다.

<br/>
휴... 아무튼 이러한 변화를 바탕으로

## PropertyWindow 에서 팩토리 패턴 활용한 구현
Property 에는 `type`(input 타입: 숫자, 드랍다운 등), `name`: 너비 등의 정보, `value`가 들어옵니다!
type에 맞게 PropertyRenderer를 불러오는 식으로 구현했습니다!
기존에 있던 `Editable`의 경우 `READ`타입을 따로 둬서 고정값도 볼 수 있게 했습니다! 
<br/>
## 코멘트
언제든 질문 주세요...

