### PR TITLE
테두리 그림자와 도형이 겹치는 문제 수정

### DIFF
--- a/src/components/propertyRenderFactory.tsx
+++ b/src/components/propertyRenderFactory.tsx
@@ -1,43 +1,49 @@
 import React from "react";
-import { ColorRenderer, DropdownRenderer, NumberRenderer, ReadOnlyRenderer, TextRenderer } from "./propertyRenderers";
+import {
+  ColorRenderer,
+  DropdownRenderer,
+  NumberRenderer,
+  ReadOnlyRenderer,
+  TextRenderer,
+} from "./propertyRenderers";
 import { PROPERTY_TYPES } from "../constants";
 
-
 type RendererProps = {
-    name: string;
-    value: string | number;
-    onChange: (newValue: string | number) => void;
+  name: string;
+  value: string | number;
+  onChange: (newValue: string | number) => void;
 };
 
 const rendererMap: Record<string, (props: RendererProps) => React.ReactNode> = {
-    [PROPERTY_TYPES.COLOR]: ({ name, value, onChange }) => (
-      <ColorRenderer name={name} value={value} onChange={onChange} />
-    ),
-    [PROPERTY_TYPES.TEXT]: ({ name, value, onChange }) => (
-      <TextRenderer name={name} value={value} onChange={onChange} />
-    ),
-    [PROPERTY_TYPES.NUMBER]: ({ name, value, onChange }) => (
-      <NumberRenderer name={name} value={value} onChange={onChange} />
-    ),
-    [PROPERTY_TYPES.DROPDOWN]: ({ name, value, onChange }) => (
-      <DropdownRenderer name={name} value={value} onChange={onChange} />
-    ),
-    [PROPERTY_TYPES.READ]: ({ name, value }) => (
-      <ReadOnlyRenderer name={name} value={value} onChange={() => {}} />
-    ),
+  [PROPERTY_TYPES.COLOR]: ({ name, value, onChange }) => (
+    <ColorRenderer name={name} value={value} onChange={onChange} />
+  ),
+  [PROPERTY_TYPES.TEXT]: ({ name, value, onChange }) => (
+    <TextRenderer name={name} value={value} onChange={onChange} />
+  ),
+  [PROPERTY_TYPES.NUMBER]: ({ name, value, onChange }) => (
+    <NumberRenderer
+      name={name}
+      value={typeof value === "number" ? Math.abs(value) : value}
+      onChange={onChange}
+    />
+  ),
+  [PROPERTY_TYPES.DROPDOWN]: ({ name, value, onChange }) => (
+    <DropdownRenderer name={name} value={value} onChange={onChange} />
+  ),
+  [PROPERTY_TYPES.READ]: ({ name, value }) => (
+    <ReadOnlyRenderer name={name} value={value} onChange={() => {}} />
+  ),
 };
-  
 
 export class PropertyRendererFactory {
-    static createRenderer(
-        type: string,
-        name: string,
-        value: string | number,
-        onChange: (newValue: string | number) => void
-    ): React.ReactNode {
-        const renderer = rendererMap[type];
-        return renderer
-            ? renderer({ name, value, onChange })
-            : null;
-    }
+  static createRenderer(
+    type: string,
+    name: string,
+    value: string | number,
+    onChange: (newValue: string | number) => void
+  ): React.ReactNode {
+    const renderer = rendererMap[type];
+    return renderer ? renderer({ name, value, onChange }) : null;
+  }
 }

--- a/src/entity/shape/Ellipse.ts
+++ b/src/entity/shape/Ellipse.ts
@@ -1,5 +1,9 @@
 import { PROPERTY_NAMES, PROPERTY_TYPES } from "../../constants";
-import { BorderedShapePropertyHandlers, CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import {
+  BorderedShapePropertyHandlers,
+  CommonPropertyHandlers,
+  PropertyHandler,
+} from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
 export class Ellipse extends AbstractShape {
@@ -15,10 +19,11 @@ export class Ellipse extends AbstractShape {
   }
 
   draw(ctx: CanvasRenderingContext2D) {
-    ctx.strokeStyle = this.borderColor;
-    ctx.lineWidth = this.borderWidth;
+    if (!ctx) throw new Error("context is null");
+    ctx.save();
 
     this.setShadow(ctx);
+    this.drawFrame(ctx); // 테두리 그림자 반영하기
     ctx.fillStyle = this.color;
     ctx.beginPath();
     ctx.ellipse(
@@ -33,6 +38,14 @@ export class Ellipse extends AbstractShape {
     ctx.fill();
     ctx.closePath();
 
+    ctx.restore();
+    this.drawFrame(ctx);
+    ctx.restore();
+  }
+
+  drawFrame(ctx: CanvasRenderingContext2D) {
+    ctx.strokeStyle = this.borderColor;
+    ctx.lineWidth = this.borderWidth;
     if (this.borderWidth > 0) {
       ctx.beginPath();
       ctx.ellipse(
@@ -48,7 +61,6 @@ export class Ellipse extends AbstractShape {
       ctx.closePath();
     }
   }
-
   isPointInside(x: number, y: number): boolean {
     const centerX = this.centerX;
     const centerY = this.centerY;
@@ -72,7 +84,7 @@ export class Ellipse extends AbstractShape {
       const centerX = shape.centerX;
       shape.startX = centerX - Number(value) / 2;
       shape.endX = centerX + Number(value) / 2;
-    }
+    },
   });
   private static HeightHandler = (): PropertyHandler<Ellipse> => ({
     type: PROPERTY_TYPES.NUMBER,
@@ -82,21 +94,25 @@ export class Ellipse extends AbstractShape {
       const centerY = shape.centerY;
       shape.startY = centerY - Number(value) / 2;
       shape.endY = centerY + Number(value) / 2;
-    }
+    },
   });
   protected getPropertyHandlers(): PropertyHandler<this>[] {
-      return [
-          CommonPropertyHandlers.HorizontalPos(),
-          CommonPropertyHandlers.VerticalPos(),
-          Ellipse.WidthHandler(),
-          Ellipse.HeightHandler(),
-          CommonPropertyHandlers.Color(),
-          CommonPropertyHandlers.ShadowAngle(),
-          CommonPropertyHandlers.ShadowRadius(),
-          CommonPropertyHandlers.ShadowBlur(),
-          CommonPropertyHandlers.ShadowColor(),
-          BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>(),
-          BorderedShapePropertyHandlers.BorderColor<this & { borderColor: string }>(),
-      ];
+    return [
+      CommonPropertyHandlers.HorizontalPos(),
+      CommonPropertyHandlers.VerticalPos(),
+      Ellipse.WidthHandler(),
+      Ellipse.HeightHandler(),
+      CommonPropertyHandlers.Color(),
+      CommonPropertyHandlers.ShadowAngle(),
+      CommonPropertyHandlers.ShadowRadius(),
+      CommonPropertyHandlers.ShadowBlur(),
+      CommonPropertyHandlers.ShadowColor(),
+      BorderedShapePropertyHandlers.BorderWidth<
+        this & { borderWidth: number }
+      >(),
+      BorderedShapePropertyHandlers.BorderColor<
+        this & { borderColor: string }
+      >(),
+    ];
   }
 }

--- a/src/entity/shape/ImageShape.ts
+++ b/src/entity/shape/ImageShape.ts
@@ -1,4 +1,8 @@
-import { BorderedShapePropertyHandlers, CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import {
+  BorderedShapePropertyHandlers,
+  CommonPropertyHandlers,
+  PropertyHandler,
+} from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
 export class ImageShape extends AbstractShape {
@@ -8,9 +12,9 @@ export class ImageShape extends AbstractShape {
     startY: number,
     endX: number,
     endY: number,
-    public imageUrl: string,
+    public imageUrl: string
   ) {
-      super(id, startX, startY, endX, endY);
+    super(id, startX, startY, endX, endY);
   }
   private borderWidth: number = 0;
   private borderColor: string = "#000000";
@@ -19,8 +23,10 @@ export class ImageShape extends AbstractShape {
 
   draw(ctx: CanvasRenderingContext2D | null): void {
     if (!ctx) throw new Error("context is null");
+    ctx.save();
 
     this.setShadow(ctx);
+    this.drawFrame(ctx); // 테두리 그림자 반영하기
 
     if (!this.imageElement) {
       this.imageElement = new Image();
@@ -44,6 +50,12 @@ export class ImageShape extends AbstractShape {
       );
     }
 
+    ctx.restore();
+    this.drawFrame(ctx);
+    ctx.restore();
+  }
+
+  drawFrame(ctx: CanvasRenderingContext2D) {
     if (this.borderWidth > 0) {
       ctx.strokeStyle = this.borderColor;
       ctx.lineWidth = this.borderWidth;
@@ -60,20 +72,23 @@ export class ImageShape extends AbstractShape {
     );
   }
 
-
   protected getPropertyHandlers(): PropertyHandler<this>[] {
     return [
-        CommonPropertyHandlers.HorizontalPos(),
-        CommonPropertyHandlers.VerticalPos(),
-        CommonPropertyHandlers.Width(),
-        CommonPropertyHandlers.Height(),
-        CommonPropertyHandlers.Color(),
-        CommonPropertyHandlers.ShadowAngle(),
-        CommonPropertyHandlers.ShadowRadius(),
-        CommonPropertyHandlers.ShadowBlur(),
-        CommonPropertyHandlers.ShadowColor(),
-        BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>(),
-        BorderedShapePropertyHandlers.BorderColor<this & { borderColor: string }>(),
+      CommonPropertyHandlers.HorizontalPos(),
+      CommonPropertyHandlers.VerticalPos(),
+      CommonPropertyHandlers.Width(),
+      CommonPropertyHandlers.Height(),
+      CommonPropertyHandlers.Color(),
+      CommonPropertyHandlers.ShadowAngle(),
+      CommonPropertyHandlers.ShadowRadius(),
+      CommonPropertyHandlers.ShadowBlur(),
+      CommonPropertyHandlers.ShadowColor(),
+      BorderedShapePropertyHandlers.BorderWidth<
+        this & { borderWidth: number }
+      >(),
+      BorderedShapePropertyHandlers.BorderColor<
+        this & { borderColor: string }
+      >(),
     ];
   }
 }

--- a/src/entity/shape/Line.ts
+++ b/src/entity/shape/Line.ts
@@ -1,31 +1,27 @@
 import { PROPERTY_NAMES, PROPERTY_TYPES } from "../../constants";
-import { CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import {
+  CommonPropertyHandlers,
+  PropertyHandler,
+} from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
 export class Line extends AbstractShape {
-  constructor(
-    id: number,
-    startX: number,
-    startY: number,
-    endX: number,
-    endY: number,
-  ) {
-    super(id, startX, startY, endX, endY);
-  }
   lineWidth: number = 1;
 
   get dx(): number {
     return this.endX - this.startX;
   }
   get dy(): number {
-      return this.endY - this.startY;
+    return this.endY - this.startY;
   }
   get length(): number {
-      return Math.sqrt(this.dx * this.dx + this.dy * this.dy);
+    return Math.sqrt(this.dx * this.dx + this.dy * this.dy);
   }
 
   draw(ctx: CanvasRenderingContext2D): void {
     if (!ctx) throw new Error("context is null");
+    ctx.save();
+
     ctx.strokeStyle = this.color;
     ctx.lineWidth = this.lineWidth;
     this.setShadow(ctx);
@@ -33,6 +29,9 @@ export class Line extends AbstractShape {
     ctx.moveTo(this.startX, this.startY);
     ctx.lineTo(this.endX, this.endY);
     ctx.stroke();
+    ctx.closePath();
+
+    ctx.restore();
   }
 
   override getResizeHandles(): { x: number; y: number; pos: string }[] {
@@ -107,21 +106,21 @@ export class Line extends AbstractShape {
     name: PROPERTY_NAMES.LINEWIDTH,
     getValue: (shape) => shape.lineWidth,
     setValue: (shape, value) => {
-        shape.lineWidth = Number(value);
+      shape.lineWidth = Number(value);
     },
   });
 
   protected getPropertyHandlers(): PropertyHandler<this>[] {
     return [
-        CommonPropertyHandlers.HorizontalPos(),
-        CommonPropertyHandlers.VerticalPos(),
-        Line.LengthHandler(),
-        Line.LineWidthHandler(),
-        CommonPropertyHandlers.Color(),
-        CommonPropertyHandlers.ShadowAngle(),
-        CommonPropertyHandlers.ShadowRadius(),
-        CommonPropertyHandlers.ShadowBlur(),
-        CommonPropertyHandlers.ShadowColor(),
+      CommonPropertyHandlers.HorizontalPos(),
+      CommonPropertyHandlers.VerticalPos(),
+      Line.LengthHandler(),
+      Line.LineWidthHandler(),
+      CommonPropertyHandlers.Color(),
+      CommonPropertyHandlers.ShadowAngle(),
+      CommonPropertyHandlers.ShadowRadius(),
+      CommonPropertyHandlers.ShadowBlur(),
+      CommonPropertyHandlers.ShadowColor(),
     ];
   }
 }

--- a/src/entity/shape/Rectangle.ts
+++ b/src/entity/shape/Rectangle.ts
@@ -1,4 +1,8 @@
-import { BorderedShapePropertyHandlers, CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import {
+  BorderedShapePropertyHandlers,
+  CommonPropertyHandlers,
+  PropertyHandler,
+} from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
 export class Rectangle extends AbstractShape {
@@ -7,18 +11,26 @@ export class Rectangle extends AbstractShape {
 
   draw(ctx: CanvasRenderingContext2D) {
     if (!ctx) throw new Error("context is null");
+    ctx.save();
     this.setShadow(ctx);
+    this.drawFrame(ctx); // 테두리 그림자 반영하기
 
     ctx.fillStyle = this.color;
     ctx.fillRect(this.startX, this.startY, this.width, this.height);
 
-    // 프레임
+    ctx.restore();
+    this.drawFrame(ctx);
+    ctx.restore();
+  }
+
+  drawFrame(ctx: CanvasRenderingContext2D) {
     if (this.borderWidth > 0) {
       ctx.strokeStyle = this.borderColor;
       ctx.lineWidth = this.borderWidth;
       ctx.strokeRect(this.startX, this.startY, this.width, this.height);
     }
   }
+
   isPointInside(x: number, y: number): boolean {
     return (
       x >= Math.min(this.startX, this.endX) &&
@@ -30,17 +42,21 @@ export class Rectangle extends AbstractShape {
 
   protected getPropertyHandlers(): PropertyHandler<this>[] {
     return [
-        CommonPropertyHandlers.HorizontalPos(),
-        CommonPropertyHandlers.VerticalPos(),
-        CommonPropertyHandlers.Width(),
-        CommonPropertyHandlers.Height(),
-        CommonPropertyHandlers.Color(),
-        CommonPropertyHandlers.ShadowAngle(),
-        CommonPropertyHandlers.ShadowRadius(),
-        CommonPropertyHandlers.ShadowBlur(),
-        CommonPropertyHandlers.ShadowColor(),
-        BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>(),
-        BorderedShapePropertyHandlers.BorderColor<this & { borderColor: string }>(),
+      CommonPropertyHandlers.HorizontalPos(),
+      CommonPropertyHandlers.VerticalPos(),
+      CommonPropertyHandlers.Width(),
+      CommonPropertyHandlers.Height(),
+      CommonPropertyHandlers.Color(),
+      CommonPropertyHandlers.ShadowAngle(),
+      CommonPropertyHandlers.ShadowRadius(),
+      CommonPropertyHandlers.ShadowBlur(),
+      CommonPropertyHandlers.ShadowColor(),
+      BorderedShapePropertyHandlers.BorderWidth<
+        this & { borderWidth: number }
+      >(),
+      BorderedShapePropertyHandlers.BorderColor<
+        this & { borderColor: string }
+      >(),
     ];
   }
 }

--- a/src/entity/shape/Shape.ts
+++ b/src/entity/shape/Shape.ts
@@ -7,15 +7,9 @@ export interface Shape {
   readonly startY: number;
   readonly endX: number;
   readonly endY: number;
-  readonly color: string;
-  readonly width: number;
-  readonly height: number;
-  readonly centerX: number;
-  readonly centerY: number;
 
   draw(ctx: CanvasRenderingContext2D | null): void;
   move(dx: number, dy: number): void;
-  setShadow(ctx: CanvasRenderingContext2D): void;
   getResizeHandles(): { x: number; y: number; pos: string }[];
   resize(dx: number, dy: number, pos: string): void;
   isPointInside(x: number, y: number): boolean;

--- a/src/entity/shape/Shape.ts
+++ b/src/entity/shape/Shape.ts
@@ -2,12 +2,12 @@ import { DEFAULT_SHAPE } from "../../constants";
 import { Property, PropertyHandler } from "../property/PropertyHandlers";
 
 export interface Shape {
-  id: number;
-  startX: number;
-  startY: number;
-  endX: number;
-  endY: number;
-  color: string;
+  readonly id: number;
+  readonly startX: number;
+  readonly startY: number;
+  readonly endX: number;
+  readonly endY: number;
+  readonly color: string;
   readonly width: number;
   readonly height: number;
   readonly centerX: number;
@@ -25,11 +25,11 @@ export interface Shape {
 
 export abstract class AbstractShape implements Shape {
   constructor(
-      public id: number,
-      public startX: number,
-      public startY: number,
-      public endX: number,
-      public endY: number,
+    public id: number,
+    public startX: number,
+    public startY: number,
+    public endX: number,
+    public endY: number
   ) {}
   textContent: string = DEFAULT_SHAPE.TEXT_CONTENT;
   color: string = "#000000";
@@ -40,16 +40,16 @@ export abstract class AbstractShape implements Shape {
   shadowBlur: number = 0;
 
   get width(): number {
-      return Math.abs(this.endX - this.startX);
+    return this.endX - this.startX;
   }
   get height(): number {
-      return Math.abs(this.endY - this.startY);
+    return this.endY - this.startY;
   }
   get centerX(): number {
-      return (this.startX + this.endX) / 2
+    return (this.startX + this.endX) / 2;
   }
   get centerY(): number {
-      return (this.startY + this.endY) / 2
+    return (this.startY + this.endY) / 2;
   }
   get shadowAngle(): number {
     return Math.atan2(this.shadowOffsetY, this.shadowOffsetX);
@@ -64,12 +64,12 @@ export abstract class AbstractShape implements Shape {
   }
 
   move(dx: number, dy: number): void {
-      this.startX += dx;
-      this.startY += dy;
-      this.endX += dx;
-      this.endY += dy;
+    this.startX += dx;
+    this.startY += dy;
+    this.endX += dx;
+    this.endY += dy;
   }
-  
+
   setShadow(ctx: CanvasRenderingContext2D): void {
     ctx.shadowColor = this.shadowColor;
     ctx.shadowOffsetX = this.shadowOffsetX;
@@ -79,34 +79,34 @@ export abstract class AbstractShape implements Shape {
 
   // 4개 꼭지점 기준
   // Line은 override 필요
-  getResizeHandles(): { x: number; y: number; pos: string; }[] {
-      return [
-          { x: this.startX - 5, y: this.startY - 5, pos: "top-left" },
-          { x: this.endX - 5, y: this.startY - 5, pos: "top-right" },
-          { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" },
-          { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" },
-      ];
+  getResizeHandles(): { x: number; y: number; pos: string }[] {
+    return [
+      { x: this.startX - 5, y: this.startY - 5, pos: "top-left" },
+      { x: this.endX - 5, y: this.startY - 5, pos: "top-right" },
+      { x: this.endX - 5, y: this.endY - 5, pos: "bottom-right" },
+      { x: this.startX - 5, y: this.endY - 5, pos: "bottom-left" },
+    ];
   }
   // Line은 override 필요
   resize(dx: number, dy: number, pos: string): void {
-      switch (pos) {
-          case "top-left":
-            this.startX += dx;
-            this.startY += dy;
-            break;
-          case "top-right":
-            this.endX += dx;
-            this.startY += dy;
-            break;
-          case "bottom-right":
-            this.endX += dx;
-            this.endY += dy;
-            break;
-          case "bottom-left":
-            this.startX += dx;
-            this.endY += dy;
-            break;
-        }
+    switch (pos) {
+      case "top-left":
+        this.startX += dx;
+        this.startY += dy;
+        break;
+      case "top-right":
+        this.endX += dx;
+        this.startY += dy;
+        break;
+      case "bottom-right":
+        this.endX += dx;
+        this.endY += dy;
+        break;
+      case "bottom-left":
+        this.startX += dx;
+        this.endY += dy;
+        break;
+    }
   }
 
   abstract draw(ctx: CanvasRenderingContext2D): void;
@@ -115,37 +115,37 @@ export abstract class AbstractShape implements Shape {
   protected abstract getPropertyHandlers(): PropertyHandler<this>[];
 
   getProperties(): Property[] {
-      return this.getPropertyHandlers().map(handler => ({
-          type: handler.type,
-          name: handler.name,
-          value: handler.getValue(this),
-      }));
+    return this.getPropertyHandlers().map((handler) => ({
+      type: handler.type,
+      name: handler.name,
+      value: handler.getValue(this),
+    }));
   }
 
   setProperties(name: string, value: any): void {
-      const handler = this.getPropertyHandlers().find(h => h.name === name);
-      if (!handler) throw new Error(`Invalid property name: ${name}`);
-      handler.setValue(this, value);
+    const handler = this.getPropertyHandlers().find((h) => h.name === name);
+    if (!handler) throw new Error(`Invalid property name: ${name}`);
+    handler.setValue(this, value);
   }
 
   setCenterX(newX: number): void {
-      const width = this.width;
-      this.startX = newX - width / 2;
-      this.endX = newX + width / 2;
+    const width = this.width;
+    this.startX = newX - width / 2;
+    this.endX = newX + width / 2;
   }
   setCenterY(newY: number): void {
-      const height = this.height;
-      this.startY = newY - height / 2;
-      this.endY = newY + height / 2;
+    const height = this.height;
+    this.startY = newY - height / 2;
+    this.endY = newY + height / 2;
   }
   setWidth(newWidth: number): void {
-      const centerX = this.centerX;
-      this.startX = centerX - newWidth / 2;
-      this.endX = centerX + newWidth / 2;
+    const centerX = this.centerX;
+    this.startX = centerX - newWidth / 2;
+    this.endX = centerX + newWidth / 2;
   }
   setHeight(newHeight: number): void {
-      const centerY = this.centerY;
-      this.startY = centerY - newHeight / 2;
-      this.endY = centerY + newHeight / 2;
+    const centerY = this.centerY;
+    this.startY = centerY - newHeight / 2;
+    this.endY = centerY + newHeight / 2;
   }
 }

--- a/src/entity/shape/TextShape.ts
+++ b/src/entity/shape/TextShape.ts
@@ -1,84 +1,93 @@
 import { DEFAULT_SHAPE, PROPERTY_NAMES, PROPERTY_TYPES } from "../../constants";
-import { CommonPropertyHandlers, PropertyHandler } from "../property/PropertyHandlers";
+import {
+  CommonPropertyHandlers,
+  PropertyHandler,
+} from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
 export class TextShape extends AbstractShape {
-    public isEditing: boolean = false;
-    constructor(
-        id: number,
-        startX: number,
-        startY: number,
-        endX: number,
-        endY: number,
-        public textContent: string = DEFAULT_SHAPE.TEXT_CONTENT,
-        public fontSize: number = DEFAULT_SHAPE.FONT_SIZE,
-        public fontFamily: string = DEFAULT_SHAPE.FONT_FAMILY,
-    ) {
-        super(id, startX, startY, endX, endY);
-    }
+  public isEditing: boolean = false;
+  constructor(
+    id: number,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    public textContent: string = DEFAULT_SHAPE.TEXT_CONTENT,
+    public fontSize: number = DEFAULT_SHAPE.FONT_SIZE,
+    public fontFamily: string = DEFAULT_SHAPE.FONT_FAMILY
+  ) {
+    super(id, startX, startY, endX, endY);
+  }
 
-    draw(ctx: CanvasRenderingContext2D | null): void {
-        if (!ctx) throw new Error("context is null");
-        if (this.isEditing) return;
-        this.setShadow(ctx);
+  draw(ctx: CanvasRenderingContext2D | null): void {
+    if (!ctx) throw new Error("context is null");
+    ctx.save();
+    if (this.isEditing) return;
+    this.setShadow(ctx);
 
-        ctx.font = `${this.fontSize}px ${this.fontFamily}`;
-        ctx.fillStyle = this.color;
+    ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+    ctx.fillStyle = this.color;
 
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText(this.textContent, this.centerX, this.centerY);
-    }
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(this.textContent, this.centerX, this.centerY);
+    ctx.restore();
+  }
 
-    isPointInside(x: number, y: number): boolean {
-        return (
-            x >= Math.min(this.startX, this.endX) &&
-            x <= Math.max(this.startX, this.endX) &&
-            y >= Math.min(this.startY, this.endY) &&
-            y <= Math.max(this.startY, this.endY)
-        );
-    }
+  isPointInside(x: number, y: number): boolean {
+    return (
+      x >= Math.min(this.startX, this.endX) &&
+      x <= Math.max(this.startX, this.endX) &&
+      y >= Math.min(this.startY, this.endY) &&
+      y <= Math.max(this.startY, this.endY)
+    );
+  }
 
-    private static fontSizeHandler = (): PropertyHandler<TextShape> => ({
-        type: PROPERTY_TYPES.NUMBER,
-        name: PROPERTY_NAMES.FONT_SIZE,
-        getValue: (shape) => shape.fontSize,
-        setValue: (shape, value) => { shape.fontSize = Number(value); }
-    });
+  private static fontSizeHandler = (): PropertyHandler<TextShape> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.FONT_SIZE,
+    getValue: (shape) => shape.fontSize,
+    setValue: (shape, value) => {
+      shape.fontSize = Number(value);
+    },
+  });
 
-    private static fontFamilyHandler = (): PropertyHandler<TextShape> => ({
-        type: PROPERTY_TYPES.DROPDOWN,
-        name: PROPERTY_NAMES.FONT_FAMILY,
-        getValue: (shape) => shape.fontFamily,
-        setValue: (shape, value) => { shape.fontFamily = value.toString(); }
-    });
+  private static fontFamilyHandler = (): PropertyHandler<TextShape> => ({
+    type: PROPERTY_TYPES.DROPDOWN,
+    name: PROPERTY_NAMES.FONT_FAMILY,
+    getValue: (shape) => shape.fontFamily,
+    setValue: (shape, value) => {
+      shape.fontFamily = value.toString();
+    },
+  });
 
-    protected getPropertyHandlers(): PropertyHandler<this>[] {
-        return [
-            CommonPropertyHandlers.HorizontalPos(),
-            CommonPropertyHandlers.VerticalPos(),
-            CommonPropertyHandlers.textContentHandler(),
-            TextShape.fontSizeHandler(),
-            TextShape.fontFamilyHandler(),
-            CommonPropertyHandlers.Width(),
-            CommonPropertyHandlers.Height(),
-            CommonPropertyHandlers.Color(),
-            CommonPropertyHandlers.ShadowAngle(),
-            CommonPropertyHandlers.ShadowRadius(),
-            CommonPropertyHandlers.ShadowBlur(),
-            CommonPropertyHandlers.ShadowColor(),    
-        ];
-    }
+  protected getPropertyHandlers(): PropertyHandler<this>[] {
+    return [
+      CommonPropertyHandlers.HorizontalPos(),
+      CommonPropertyHandlers.VerticalPos(),
+      CommonPropertyHandlers.textContentHandler(),
+      TextShape.fontSizeHandler(),
+      TextShape.fontFamilyHandler(),
+      CommonPropertyHandlers.Width(),
+      CommonPropertyHandlers.Height(),
+      CommonPropertyHandlers.Color(),
+      CommonPropertyHandlers.ShadowAngle(),
+      CommonPropertyHandlers.ShadowRadius(),
+      CommonPropertyHandlers.ShadowBlur(),
+      CommonPropertyHandlers.ShadowColor(),
+    ];
+  }
 }
 
 export interface TextShapeProps {
-    id: number;
-    textContent: string;
-    startX: number;
-    startY: number;
-    endX: number;
-    endY: number;
-    fontSize: number;
-    fontFamily: string;
-    color: string;
+  id: number;
+  textContent: string;
+  startX: number;
+  startY: number;
+  endX: number;
+  endY: number;
+  fontSize: number;
+  fontFamily: string;
+  color: string;
 }

--- a/src/view/Toolbar.tsx
+++ b/src/view/Toolbar.tsx
@@ -33,7 +33,6 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
       <button
         className={`tool-button ${isActive("rectangle") ? "active" : ""}`}
         onClick={() => {
-          viewModel.setShapeType("rectangle");
           viewModel.requestSetState("DrawState", { shapeType: "rectangle" });
         }}
       >
@@ -43,7 +42,6 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
       <button
         className={`tool-button ${isActive("ellipse") ? "active" : ""}`}
         onClick={() => {
-          viewModel.setShapeType("ellipse");
           viewModel.requestSetState("DrawState", { shapeType: "ellipse" });
         }}
       >
@@ -53,7 +51,6 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
       <button
         className={`tool-button ${isActive("line") ? "active" : ""}`}
         onClick={() => {
-          viewModel.setShapeType("line");
           viewModel.requestSetState("DrawState", { shapeType: "line" });
         }}
       >
@@ -88,7 +85,6 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
                     height: baseHeight,
                   });
 
-                  viewModel.setShapeType("");
                   viewModel.requestSetState("SelectState", {});
                 };
                 img.onerror = () => {
@@ -110,8 +106,7 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
           viewModel.requestAddTemplateShape("text", {
             width: DEFAULT_SHAPE.WIDTH,
             height: DEFAULT_SHAPE.HEIGHT,
-          })
-          viewModel.setShapeType("");
+          });
           viewModel.requestSetState("SelectState", {});
         }}
       >
@@ -121,7 +116,6 @@ const Toolbar: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
       <button
         className={`tool-button ${isSelectActive() ? "active" : ""}`}
         onClick={() => {
-          viewModel.setShapeType("");
           viewModel.requestSetState("SelectState", {});
         }}
       >

--- a/src/viewModel/CanvasViewModel.ts
+++ b/src/viewModel/CanvasViewModel.ts
@@ -8,7 +8,12 @@ import { DrawState } from "./canvasState/DrawState";
 import { ResizeState } from "./canvasState/ResizeState";
 import { SelectedShapeModel } from "../model/SelectedShapeModel";
 import { CanvasStateCommandFactory } from "./canvasState/CanvasStateCommandFactory";
-import { AddTemplateShapeCommand, CanvasResetCommand, SetPropertyCommand, ZOrderMoveCommand } from "../command";
+import {
+  AddTemplateShapeCommand,
+  CanvasResetCommand,
+  SetPropertyCommand,
+  ZOrderMoveCommand,
+} from "../command";
 
 export class CanvasViewModel extends Observable<any> {
   private shapeModel: ShapeModel;
@@ -60,8 +65,8 @@ export class CanvasViewModel extends Observable<any> {
 
   handleDoubleClick = (event: React.MouseEvent) => {
     this.state.handleDoubleClick(event);
-    this.notifyShapesUpdated(); 
-  }
+    this.notifyShapesUpdated();
+  };
 
   requestResetCanvas() {
     const command = new CanvasResetCommand(
@@ -96,6 +101,9 @@ export class CanvasViewModel extends Observable<any> {
   }
 
   requestSetState(stateType: string, params: any) {
+    if (stateType === "DrawState") {
+      this.setShapeType(params.shapeType); // shapeType을 DrawState에 전달
+    } else this.setShapeType("");
     const command = this.canvasStateCommandFactory.createCommand(
       stateType,
       params
@@ -134,7 +142,7 @@ export class CanvasViewModel extends Observable<any> {
       this.shapeModel,
       this.selectedShapeModel,
       type,
-      properties,
+      properties
     );
     command.execute();
     this.notifyShapesUpdated();


### PR DESCRIPTION
**#22 도형 그림자 수정**
기존에 도형 그림자 -> 도형 -> 테두리 그림자 -> 테두리 순으로 그려져 테두리 그림자가 도형 위에 표시되는 문제를 고쳤습니다.
각 도형의 draw() 메서드에서
1. 기존 ctx 상태 저장
a. shadow 설정
b. 테두리, 도형 그리기: 자동으로 테두리, 도형 그림자 생성됨
2. ctx 되돌리기
a. 테두리 그리기: 그림자 없음
3. 되돌리기

이런 순서로 그리도록 변경했습니다! 마지막에 ctx 되돌리기를 한번 더 호출해서 현재 도형의 테두리 설정 값이 다른 도형에도 적용되지 않도록 방지합니다.

**그 외 수정사항**
toolbar view에서 `canvasViewModel.setShapeType()`을 직접 호출하지 않도록, `canvasViewModel.requestSetState()`에 `setShapeType`을 추가했습니다. 
Shape interface에서 public으로 정의된 속성 중 불필요한 속성을 삭제하고, 일부는 readonly로 정의했습니다.
속성과 메서드를 어디까지 public으로 정의해도 되는지 고민한 흔적입니당.