### PR TITLE
모든 도형에 텍스트 속성 추가

### DIFF
--- a/src/components/propertyRenderFactory.tsx
+++ b/src/components/propertyRenderFactory.tsx
@@ -5,14 +5,43 @@ import {
   NumberRenderer,
   ReadOnlyRenderer,
   TextRenderer,
+  BooleanRenderer,
 } from "./propertyRenderers";
-import { PROPERTY_TYPES } from "../constants";
+import { PROPERTY_TYPES, PROPERTY_NAMES } from "../constants";
 
 type RendererProps = {
   name: string;
-  value: string | number;
-  onChange: (newValue: string | number) => void;
+  value: string | number | boolean;
+  onChange: (newValue: string | number | boolean) => void;
 };
+
+type PropertyItem = {
+  type: string;
+  name: string;
+  value: string | number | boolean;
+};
+
+type GroupedProperties = Record<string, PropertyItem[]>;
+
+function getPropertyKeyByName(name: string): string | undefined {
+  return Object.keys(PROPERTY_NAMES).find(
+    (key) => PROPERTY_NAMES[key as keyof typeof PROPERTY_NAMES] === name
+  );
+}
+
+function groupPropertiesByKeyPrefix(
+  properties: PropertyItem[]
+): GroupedProperties {
+  const groupMap: GroupedProperties = {};
+  properties.forEach((prop) => {
+    const key = getPropertyKeyByName(prop.name) || prop.name;
+    const match = key.match(/^[A-Z]+/);
+    const group = match ? match[0] : "기타";
+    if (!groupMap[group]) groupMap[group] = [];
+    groupMap[group].push(prop);
+  });
+  return groupMap;
+}
 
 const rendererMap: Record<string, (props: RendererProps) => React.ReactNode> = {
   [PROPERTY_TYPES.COLOR]: ({ name, value, onChange }) => (
@@ -34,16 +63,39 @@ const rendererMap: Record<string, (props: RendererProps) => React.ReactNode> = {
   [PROPERTY_TYPES.READ]: ({ name, value }) => (
     <ReadOnlyRenderer name={name} value={value} onChange={() => {}} />
   ),
+  [PROPERTY_TYPES.BOOLEAN]: ({ name, value, onChange }) => (
+    <BooleanRenderer name={name} value={value} onChange={onChange} />
+  ),
 };
 
 export class PropertyRendererFactory {
   static createRenderer(
     type: string,
     name: string,
-    value: string | number,
-    onChange: (newValue: string | number) => void
+    value: string | number | boolean,
+    onChange: (newValue: string | number | boolean) => void
   ): React.ReactNode {
     const renderer = rendererMap[type];
     return renderer ? renderer({ name, value, onChange }) : null;
+  }
+
+  static renderGroupedProperties(
+    properties: PropertyItem[],
+    onChange: (name: string, value: string | number | boolean) => void
+  ): React.ReactNode {
+    const grouped = groupPropertiesByKeyPrefix(properties);
+    return Object.entries(grouped).map(([group, props]) => (
+      <div key={group} className="propertyGroup">
+        <div className="groupTitle">{group}</div>
+        {props.map((prop) =>
+          PropertyRendererFactory.createRenderer(
+            prop.type,
+            prop.name,
+            prop.value,
+            (value) => onChange(prop.name, value)
+          )
+        )}
+      </div>
+    ));
   }
 }

--- a/src/components/propertyRenderers.tsx
+++ b/src/components/propertyRenderers.tsx
@@ -3,8 +3,8 @@ import { DROPDOWN_OPTIONS } from "../constants";
 
 interface RendererProps {
   name: string;
-  value: string | number;
-  onChange: (newValue: string | number) => void;
+  value: string | number | boolean;
+  onChange: (newValue: string | number | boolean) => void;
 }
 
 export const ColorRenderer: React.FC<RendererProps> = ({ name, value, onChange }) => (
@@ -62,5 +62,27 @@ export const ReadOnlyRenderer: React.FC<RendererProps> = ({ name, value }) => (
   <div className="propertyItem" key={name}>
     <span>{name}:</span>
     <strong>{value}</strong>
+  </div>
+);
+
+export const BooleanRenderer: React.FC<RendererProps> = ({ name, value, onChange }) => (
+  <div className="propertyItem" key={name}>
+    <button
+      className={value ? "active" : ""}
+      onClick={() => onChange(!value)}
+      type="button"
+      style={{
+        fontWeight: name === "B" ? "bold" : undefined,
+        fontStyle: name === "I" ? "italic" : undefined,
+        background: value ? "#ddd" : "#fff",
+        border: "1px solid #ccc",
+        width: 32,
+        height: 32,
+        margin: 2,
+        cursor: "pointer",
+      }}
+    >
+      {name}
+    </button>
   </div>
 );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -17,6 +17,7 @@ export const PROPERTY_NAMES = {
   TEXT_CONTENT: "텍스트",
   FONT_FAMILY: "폰트",
   FONT_SIZE: "글자 크기",
+  FONT_COLOR: '글자 색',
   WIDTH: "너비",
   HEIGHT: "높이",
   HORIZONTAL_POS: "가로 위치",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,17 +13,19 @@ export const DEFAULT_SHAPE = {
 };
 
 export const PROPERTY_NAMES = {
-  COLOR: "색",
-  TEXT_CONTENT: "텍스트",
+  POS_HORIZONTAL: "가로 위치",
+  POS_VERTICAL: "세로 위치",
+  SHAPE_WIDTH: "너비",
+  SHAPE_HEIGHT: "높이",
+  SHAPE_COLOR: "색",
+  SHAPE_LINELENGTH: "길이",
+  SHAPE_LINEWIDTH: "선 굵기",
+  FONT_CONTENT: "텍스트",
   FONT_FAMILY: "폰트",
   FONT_SIZE: "글자 크기",
   FONT_COLOR: '글자 색',
-  WIDTH: "너비",
-  HEIGHT: "높이",
-  HORIZONTAL_POS: "가로 위치",
-  VERTICAL_POS: "세로 위치",
-  LENGTH: "길이",
-  LINEWIDTH: "선 굵기",
+  FONT_BOLD: "B",
+  FONT_ITALIC: "I",
   SHADOW_ANGLE: "그림자 각도",
   SHADOW_RADIUS: "그림자 간격",
   SHADOW_BLUR: "그림자 흐리게",
@@ -38,6 +40,7 @@ export const PROPERTY_TYPES = {
   NUMBER: "number",
   DROPDOWN: "dropdown",
   READ: "read",
+  BOOLEAN: "boolean",
 };
 
 export const DROPDOWN_OPTIONS: { [key: string]: string[] } = {

--- a/src/entity/property/PropertyHandlers.ts
+++ b/src/entity/property/PropertyHandlers.ts
@@ -3,44 +3,44 @@ import { PROPERTY_NAMES, PROPERTY_TYPES } from "../../constants";
 export interface Property {
   type: string;
   name: string;
-  value: string | number;
+  value: string | number | boolean;
 }
 
 export interface PropertyHandler<T> {
   type: string;
   name: string;
-  getValue(shape: T): string | number;
+  getValue(shape: T): string | number | boolean;
   setValue(shape: T, value: any): void;
 }
 
 export const CommonPropertyHandlers = {
   HorizontalPos: <T extends { centerX: number; setCenterX(newX: number): void }>(): PropertyHandler<T> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.HORIZONTAL_POS,
+    name: PROPERTY_NAMES.POS_HORIZONTAL,
     getValue: (shape) => Math.round(shape.centerX),
     setValue: (shape, value) => shape.setCenterX(Number(value)),
   }),
   VerticalPos: <T extends { centerY: number; setCenterY(newY: number): void }>(): PropertyHandler<T> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.VERTICAL_POS,
+    name: PROPERTY_NAMES.POS_VERTICAL,
     getValue: (shape) => Math.round(shape.centerY),
     setValue: (shape, value) => shape.setCenterY(Number(value)),
   }),
   Width: <T extends { width: number; setWidth(newWidth: number): void }>(): PropertyHandler<T> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.WIDTH,
+    name: PROPERTY_NAMES.SHAPE_WIDTH,
     getValue: (shape) => Math.round(shape.width),
     setValue: (shape, value) => shape.setWidth(Number(value)),
   }),
   Height: <T extends { height: number; setHeight(newHeight: number): void }>(): PropertyHandler<T> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.HEIGHT,
+    name: PROPERTY_NAMES.SHAPE_HEIGHT,
     getValue: (shape) => Math.round(shape.height),
     setValue: (shape, value) => shape.setHeight(Number(value)),
   }),
   Color: <T extends { color: string }>(): PropertyHandler<T> => ({
     type: PROPERTY_TYPES.COLOR,
-    name: PROPERTY_NAMES.COLOR,
+    name: PROPERTY_NAMES.SHAPE_COLOR,
     getValue: (shape) => shape.color,
     setValue: (shape, value) => { shape.color = value.toString(); },
   }),
@@ -98,7 +98,7 @@ export const BorderedShapePropertyHandlers = {
 export const TextShapePropertyHandlers = {
   TextContent: <T extends { textContent: string }> (): PropertyHandler<T> => ({
     type: PROPERTY_TYPES.TEXT,
-    name: PROPERTY_NAMES.TEXT_CONTENT,
+    name: PROPERTY_NAMES.FONT_CONTENT,
     getValue: (shape) => shape.textContent,
     setValue: (shape, value) => { shape.textContent = value.toString(); },
   }),
@@ -119,5 +119,17 @@ export const TextShapePropertyHandlers = {
     name: PROPERTY_NAMES.FONT_COLOR,
     getValue: (shape: T) => shape.fontColor,
     setValue: (shape: T, value: any) => { shape.fontColor = value.toString(); },
-  })
+  }),
+  Bold: <T extends { isBold: boolean }> (): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.BOOLEAN,
+    name: PROPERTY_NAMES.FONT_BOLD,
+    getValue: (shape: T) => shape.isBold,
+    setValue: (shape: T, value: any) => { shape.isBold = Boolean(value) },
+  }),
+  Italic: <T extends { isItalic: boolean }> (): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.BOOLEAN,
+    name: PROPERTY_NAMES.FONT_ITALIC,
+    getValue: (shape: T) => shape.isItalic,
+    setValue: (shape: T, value: any) => { shape.isItalic = Boolean(value) },
+  }),
 }

--- a/src/entity/property/PropertyHandlers.ts
+++ b/src/entity/property/PropertyHandlers.ts
@@ -78,12 +78,6 @@ export const CommonPropertyHandlers = {
     getValue: (shape) => shape.shadowColor,
     setValue: (shape, value) => { shape.shadowColor = value.toString(); },
   }),
-  textContentHandler: <T extends { textContent: string }> (): PropertyHandler<T> => ({
-    type: PROPERTY_TYPES.TEXT,
-    name: PROPERTY_NAMES.TEXT_CONTENT,
-    getValue: (shape) => shape.textContent,
-    setValue: (shape, value) => { shape.textContent = value.toString(); },
-  }),
 };
 
 export const BorderedShapePropertyHandlers = {
@@ -100,3 +94,30 @@ export const BorderedShapePropertyHandlers = {
     setValue: (shape, value) => { shape.borderColor = value.toString(); },
   }),
 };
+
+export const TextShapePropertyHandlers = {
+  TextContent: <T extends { textContent: string }> (): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.TEXT,
+    name: PROPERTY_NAMES.TEXT_CONTENT,
+    getValue: (shape) => shape.textContent,
+    setValue: (shape, value) => { shape.textContent = value.toString(); },
+  }),
+  FontSize: <T extends { fontSize: number }>(): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.NUMBER,
+    name: PROPERTY_NAMES.FONT_SIZE,
+    getValue: (shape: T) => shape.fontSize,
+    setValue: (shape: T, value: any) => { shape.fontSize = Number(value); }
+  }),
+  FontFamily: <T extends { fontFamily: string }>(): PropertyHandler<T> =>({
+    type: PROPERTY_TYPES.DROPDOWN,
+    name: PROPERTY_NAMES.FONT_FAMILY,
+    getValue: (shape: T) => shape.fontFamily,
+    setValue: (shape: T, value: any) => { shape.fontFamily = value.toString(); }
+  }),
+  FontColor: <T extends { fontColor: string }> (): PropertyHandler<T> => ({
+    type: PROPERTY_TYPES.COLOR,
+    name: PROPERTY_NAMES.FONT_COLOR,
+    getValue: (shape: T) => shape.fontColor,
+    setValue: (shape: T, value: any) => { shape.fontColor = value.toString(); },
+  })
+}

--- a/src/entity/shape/Ellipse.ts
+++ b/src/entity/shape/Ellipse.ts
@@ -45,7 +45,9 @@ export class Ellipse extends AbstractShape {
     ctx.restore();
 
     if (this.textContent) {
-      ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+      const fontStyle = this.isItalic ? "italic" : "normal";
+      const fontWeight = this.isBold ? "bold" : "normal";
+      ctx.font = `${fontStyle} ${fontWeight} ${this.fontSize}px ${this.fontFamily}`;
       ctx.fillStyle = this.fontColor;
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
@@ -88,7 +90,7 @@ export class Ellipse extends AbstractShape {
   // 사용할 속성 골라넣기
   private static WidthHandler = (): PropertyHandler<Ellipse> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.WIDTH,
+    name: PROPERTY_NAMES.SHAPE_WIDTH,
     getValue: (shape) => Math.abs(shape.radiusX * 2),
     setValue: (shape, value) => {
       const centerX = shape.centerX;
@@ -98,7 +100,7 @@ export class Ellipse extends AbstractShape {
   });
   private static HeightHandler = (): PropertyHandler<Ellipse> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.HEIGHT,
+    name: PROPERTY_NAMES.SHAPE_HEIGHT,
     getValue: (shape) => Math.abs(shape.radiusY * 2),
     setValue: (shape, value) => {
       const centerY = shape.centerY;
@@ -110,13 +112,15 @@ export class Ellipse extends AbstractShape {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
+      Ellipse.WidthHandler(),
+      Ellipse.HeightHandler(),
+      CommonPropertyHandlers.Color(),
       TextShapePropertyHandlers.TextContent(),
       this.textContent && TextShapePropertyHandlers.FontSize(),
       this.textContent && TextShapePropertyHandlers.FontFamily(),
       this.textContent && TextShapePropertyHandlers.FontColor(),
-      Ellipse.WidthHandler(),
-      Ellipse.HeightHandler(),
-      CommonPropertyHandlers.Color(),
+      this.textContent && TextShapePropertyHandlers.Bold(),
+      this.textContent && TextShapePropertyHandlers.Italic(),
       CommonPropertyHandlers.ShadowAngle(),
       CommonPropertyHandlers.ShadowRadius(),
       CommonPropertyHandlers.ShadowBlur(),

--- a/src/entity/shape/Ellipse.ts
+++ b/src/entity/shape/Ellipse.ts
@@ -10,6 +10,7 @@ import { AbstractShape } from "./Shape";
 export class Ellipse extends AbstractShape {
   private borderWidth: number = 0;
   private borderColor: string = "#000000";
+  public isTyping: boolean = false;
 
   get radiusX(): number {
     return Math.abs(this.endX - this.startX) / 2;

--- a/src/entity/shape/Ellipse.ts
+++ b/src/entity/shape/Ellipse.ts
@@ -3,6 +3,7 @@ import {
   BorderedShapePropertyHandlers,
   CommonPropertyHandlers,
   PropertyHandler,
+  TextShapePropertyHandlers,
 } from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
@@ -41,6 +42,14 @@ export class Ellipse extends AbstractShape {
     ctx.restore();
     this.drawFrame(ctx);
     ctx.restore();
+
+    if (this.textContent) {
+      ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+      ctx.fillStyle = this.fontColor;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(this.textContent, this.centerX, this.centerY);
+    }
   }
 
   drawFrame(ctx: CanvasRenderingContext2D) {
@@ -100,6 +109,10 @@ export class Ellipse extends AbstractShape {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
+      TextShapePropertyHandlers.TextContent(),
+      this.textContent && TextShapePropertyHandlers.FontSize(),
+      this.textContent && TextShapePropertyHandlers.FontFamily(),
+      this.textContent && TextShapePropertyHandlers.FontColor(),
       Ellipse.WidthHandler(),
       Ellipse.HeightHandler(),
       CommonPropertyHandlers.Color(),
@@ -113,6 +126,6 @@ export class Ellipse extends AbstractShape {
       BorderedShapePropertyHandlers.BorderColor<
         this & { borderColor: string }
       >(),
-    ];
+    ].filter(Boolean) as PropertyHandler<this>[];
   }
 }

--- a/src/entity/shape/ImageShape.ts
+++ b/src/entity/shape/ImageShape.ts
@@ -2,6 +2,7 @@ import {
   BorderedShapePropertyHandlers,
   CommonPropertyHandlers,
   PropertyHandler,
+  TextShapePropertyHandlers,
 } from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
@@ -53,6 +54,14 @@ export class ImageShape extends AbstractShape {
     ctx.restore();
     this.drawFrame(ctx);
     ctx.restore();
+
+    if (this.textContent) {
+      ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+      ctx.fillStyle = this.fontColor;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(this.textContent, this.centerX, this.centerY);
+    }
   }
 
   drawFrame(ctx: CanvasRenderingContext2D) {
@@ -76,6 +85,10 @@ export class ImageShape extends AbstractShape {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
+      TextShapePropertyHandlers.TextContent(),
+      this.textContent && TextShapePropertyHandlers.FontSize(),
+      this.textContent && TextShapePropertyHandlers.FontFamily(),
+      this.textContent && TextShapePropertyHandlers.FontColor(),
       CommonPropertyHandlers.Width(),
       CommonPropertyHandlers.Height(),
       CommonPropertyHandlers.Color(),
@@ -89,6 +102,6 @@ export class ImageShape extends AbstractShape {
       BorderedShapePropertyHandlers.BorderColor<
         this & { borderColor: string }
       >(),
-    ];
+    ].filter(Boolean) as PropertyHandler<this>[];
   }
 }

--- a/src/entity/shape/ImageShape.ts
+++ b/src/entity/shape/ImageShape.ts
@@ -19,6 +19,7 @@ export class ImageShape extends AbstractShape {
   }
   private borderWidth: number = 0;
   private borderColor: string = "#000000";
+  public isTyping: boolean = false;
 
   private imageElement: HTMLImageElement | null = null;
 

--- a/src/entity/shape/ImageShape.ts
+++ b/src/entity/shape/ImageShape.ts
@@ -57,7 +57,9 @@ export class ImageShape extends AbstractShape {
     ctx.restore();
 
     if (this.textContent) {
-      ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+      const fontStyle = this.isItalic ? "italic" : "normal";
+      const fontWeight = this.isBold ? "bold" : "normal";
+      ctx.font = `${fontStyle} ${fontWeight} ${this.fontSize}px ${this.fontFamily}`;
       ctx.fillStyle = this.fontColor;
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
@@ -86,13 +88,15 @@ export class ImageShape extends AbstractShape {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
+      CommonPropertyHandlers.Width(),
+      CommonPropertyHandlers.Height(),
+      CommonPropertyHandlers.Color(),
       TextShapePropertyHandlers.TextContent(),
       this.textContent && TextShapePropertyHandlers.FontSize(),
       this.textContent && TextShapePropertyHandlers.FontFamily(),
       this.textContent && TextShapePropertyHandlers.FontColor(),
-      CommonPropertyHandlers.Width(),
-      CommonPropertyHandlers.Height(),
-      CommonPropertyHandlers.Color(),
+      this.textContent && TextShapePropertyHandlers.Bold(),
+      this.textContent && TextShapePropertyHandlers.Italic(),
       CommonPropertyHandlers.ShadowAngle(),
       CommonPropertyHandlers.ShadowRadius(),
       CommonPropertyHandlers.ShadowBlur(),

--- a/src/entity/shape/Line.ts
+++ b/src/entity/shape/Line.ts
@@ -66,7 +66,7 @@ export class Line extends AbstractShape {
   // 길이
   private static LengthHandler = (): PropertyHandler<Line> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.LENGTH,
+    name: PROPERTY_NAMES.SHAPE_LINELENGTH,
     getValue: (shape) => Math.round(shape.length),
     setValue: (shape, value) => {
       const centerX = shape.centerX;
@@ -82,7 +82,7 @@ export class Line extends AbstractShape {
   // 선 굵기
   private static LineWidthHandler = (): PropertyHandler<Line> => ({
     type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.LINEWIDTH,
+    name: PROPERTY_NAMES.SHAPE_LINEWIDTH,
     getValue: (shape) => shape.lineWidth,
     setValue: (shape, value) => {
       shape.lineWidth = Number(value);

--- a/src/entity/shape/Rectangle.ts
+++ b/src/entity/shape/Rectangle.ts
@@ -1,7 +1,8 @@
-import {
+import { 
   BorderedShapePropertyHandlers,
   CommonPropertyHandlers,
   PropertyHandler,
+  TextShapePropertyHandlers,
 } from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
@@ -21,6 +22,14 @@ export class Rectangle extends AbstractShape {
     ctx.restore();
     this.drawFrame(ctx);
     ctx.restore();
+
+    if (this.textContent) {
+      ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+      ctx.fillStyle = this.fontColor;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(this.textContent, this.centerX, this.centerY);
+    }
   }
 
   drawFrame(ctx: CanvasRenderingContext2D) {
@@ -44,6 +53,10 @@ export class Rectangle extends AbstractShape {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
+      TextShapePropertyHandlers.TextContent(),
+      this.textContent && TextShapePropertyHandlers.FontSize(),
+      this.textContent && TextShapePropertyHandlers.FontFamily(),
+      this.textContent && TextShapePropertyHandlers.FontColor(),
       CommonPropertyHandlers.Width(),
       CommonPropertyHandlers.Height(),
       CommonPropertyHandlers.Color(),
@@ -51,12 +64,8 @@ export class Rectangle extends AbstractShape {
       CommonPropertyHandlers.ShadowRadius(),
       CommonPropertyHandlers.ShadowBlur(),
       CommonPropertyHandlers.ShadowColor(),
-      BorderedShapePropertyHandlers.BorderWidth<
-        this & { borderWidth: number }
-      >(),
-      BorderedShapePropertyHandlers.BorderColor<
-        this & { borderColor: string }
-      >(),
-    ];
+      BorderedShapePropertyHandlers.BorderWidth<this & { borderWidth: number }>(),
+      BorderedShapePropertyHandlers.BorderColor<this & { borderColor: string }>(),
+    ].filter(Boolean) as PropertyHandler<this>[];
   }
 }

--- a/src/entity/shape/Rectangle.ts
+++ b/src/entity/shape/Rectangle.ts
@@ -7,8 +7,9 @@ import {
 import { AbstractShape } from "./Shape";
 
 export class Rectangle extends AbstractShape {
-  borderWidth: number = 0;
-  borderColor: string = "#000000";
+  private borderWidth: number = 0;
+  private borderColor: string = "#000000";
+  public isTyping: boolean = false;
 
   draw(ctx: CanvasRenderingContext2D) {
     if (!ctx) throw new Error("context is null");

--- a/src/entity/shape/Rectangle.ts
+++ b/src/entity/shape/Rectangle.ts
@@ -25,7 +25,9 @@ export class Rectangle extends AbstractShape {
     ctx.restore();
 
     if (this.textContent) {
-      ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+      const fontStyle = this.isItalic ? "italic" : "normal";
+      const fontWeight = this.isBold ? "bold" : "normal";
+      ctx.font = `${fontStyle} ${fontWeight} ${this.fontSize}px ${this.fontFamily}`;
       ctx.fillStyle = this.fontColor;
       ctx.textAlign = "center";
       ctx.textBaseline = "middle";
@@ -54,13 +56,15 @@ export class Rectangle extends AbstractShape {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
+      CommonPropertyHandlers.Width(),
+      CommonPropertyHandlers.Height(),
+      CommonPropertyHandlers.Color(),
       TextShapePropertyHandlers.TextContent(),
       this.textContent && TextShapePropertyHandlers.FontSize(),
       this.textContent && TextShapePropertyHandlers.FontFamily(),
       this.textContent && TextShapePropertyHandlers.FontColor(),
-      CommonPropertyHandlers.Width(),
-      CommonPropertyHandlers.Height(),
-      CommonPropertyHandlers.Color(),
+      this.textContent && TextShapePropertyHandlers.Bold(),
+      this.textContent && TextShapePropertyHandlers.Italic(),
       CommonPropertyHandlers.ShadowAngle(),
       CommonPropertyHandlers.ShadowRadius(),
       CommonPropertyHandlers.ShadowBlur(),

--- a/src/entity/shape/Shape.ts
+++ b/src/entity/shape/Shape.ts
@@ -8,6 +8,13 @@ export interface Shape {
   readonly endX: number;
   readonly endY: number;
 
+  color: string;
+  textContent: string;
+  fontSize: number;
+  fontFamily: string;
+  fontColor: string;
+  isTyping?: boolean;
+
   draw(ctx: CanvasRenderingContext2D | null): void;
   move(dx: number, dy: number): void;
   getResizeHandles(): { x: number; y: number; pos: ResizeHandlePosition }[];

--- a/src/entity/shape/Shape.ts
+++ b/src/entity/shape/Shape.ts
@@ -25,7 +25,10 @@ export abstract class AbstractShape implements Shape {
     public endX: number,
     public endY: number
   ) {}
-  textContent: string = DEFAULT_SHAPE.TEXT_CONTENT;
+  textContent: string = "";
+  fontSize: number = DEFAULT_SHAPE.FONT_SIZE;
+  fontFamily: string = DEFAULT_SHAPE.FONT_FAMILY;
+  fontColor: string = "#fff";
   color: string = "#000000";
 
   shadowColor: string = "#000000";

--- a/src/entity/shape/Shape.ts
+++ b/src/entity/shape/Shape.ts
@@ -13,6 +13,8 @@ export interface Shape {
   fontSize: number;
   fontFamily: string;
   fontColor: string;
+  isBold: boolean;
+  isItalic: boolean;
   isTyping?: boolean;
 
   draw(ctx: CanvasRenderingContext2D | null): void;
@@ -36,6 +38,8 @@ export abstract class AbstractShape implements Shape {
   fontSize: number = DEFAULT_SHAPE.FONT_SIZE;
   fontFamily: string = DEFAULT_SHAPE.FONT_FAMILY;
   fontColor: string = "#fff";
+  isBold: boolean = false;
+  isItalic: boolean = false;
   color: string = "#000000";
 
   shadowColor: string = "#000000";

--- a/src/entity/shape/TextShape.ts
+++ b/src/entity/shape/TextShape.ts
@@ -1,7 +1,8 @@
-import { DEFAULT_SHAPE, PROPERTY_NAMES, PROPERTY_TYPES } from "../../constants";
-import {
-  CommonPropertyHandlers,
-  PropertyHandler,
+import { DEFAULT_SHAPE } from "../../constants";
+import { 
+    CommonPropertyHandlers,
+    PropertyHandler,
+    TextShapePropertyHandlers,
 } from "../property/PropertyHandlers";
 import { AbstractShape } from "./Shape";
 
@@ -15,10 +16,11 @@ export class TextShape extends AbstractShape {
     endY: number,
     public textContent: string = DEFAULT_SHAPE.TEXT_CONTENT,
     public fontSize: number = DEFAULT_SHAPE.FONT_SIZE,
-    public fontFamily: string = DEFAULT_SHAPE.FONT_FAMILY
+    public fontFamily: string = DEFAULT_SHAPE.FONT_FAMILY,
   ) {
     super(id, startX, startY, endX, endY);
   }
+  public fontColor: string = '#000000';
 
   draw(ctx: CanvasRenderingContext2D | null): void {
     if (!ctx) throw new Error("context is null");
@@ -27,7 +29,7 @@ export class TextShape extends AbstractShape {
     this.setShadow(ctx);
 
     ctx.font = `${this.fontSize}px ${this.fontFamily}`;
-    ctx.fillStyle = this.color;
+    ctx.fillStyle = this.fontColor;
 
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
@@ -44,38 +46,20 @@ export class TextShape extends AbstractShape {
     );
   }
 
-  private static fontSizeHandler = (): PropertyHandler<TextShape> => ({
-    type: PROPERTY_TYPES.NUMBER,
-    name: PROPERTY_NAMES.FONT_SIZE,
-    getValue: (shape) => shape.fontSize,
-    setValue: (shape, value) => {
-      shape.fontSize = Number(value);
-    },
-  });
-
-  private static fontFamilyHandler = (): PropertyHandler<TextShape> => ({
-    type: PROPERTY_TYPES.DROPDOWN,
-    name: PROPERTY_NAMES.FONT_FAMILY,
-    getValue: (shape) => shape.fontFamily,
-    setValue: (shape, value) => {
-      shape.fontFamily = value.toString();
-    },
-  });
-
   protected getPropertyHandlers(): PropertyHandler<this>[] {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
-      CommonPropertyHandlers.textContentHandler(),
-      TextShape.fontSizeHandler(),
-      TextShape.fontFamilyHandler(),
+      TextShapePropertyHandlers.TextContent(),
+      TextShapePropertyHandlers.FontSize(),
+      TextShapePropertyHandlers.FontFamily(),
       CommonPropertyHandlers.Width(),
       CommonPropertyHandlers.Height(),
       CommonPropertyHandlers.Color(),
       CommonPropertyHandlers.ShadowAngle(),
       CommonPropertyHandlers.ShadowRadius(),
       CommonPropertyHandlers.ShadowBlur(),
-      CommonPropertyHandlers.ShadowColor(),
+      CommonPropertyHandlers.ShadowColor(),    
     ];
   }
 }

--- a/src/entity/shape/TextShape.ts
+++ b/src/entity/shape/TextShape.ts
@@ -28,7 +28,9 @@ export class TextShape extends AbstractShape {
     if (this.isTyping) return;
     this.setShadow(ctx);
 
-    ctx.font = `${this.fontSize}px ${this.fontFamily}`;
+    const fontStyle = this.isItalic ? "italic" : "normal";
+    const fontWeight = this.isBold ? "bold" : "normal";
+    ctx.font = `${fontStyle} ${fontWeight} ${this.fontSize}px ${this.fontFamily}`;
     ctx.fillStyle = this.fontColor;
 
     ctx.textAlign = "center";
@@ -50,12 +52,14 @@ export class TextShape extends AbstractShape {
     return [
       CommonPropertyHandlers.HorizontalPos(),
       CommonPropertyHandlers.VerticalPos(),
-      TextShapePropertyHandlers.TextContent(),
-      TextShapePropertyHandlers.FontSize(),
-      TextShapePropertyHandlers.FontFamily(),
       CommonPropertyHandlers.Width(),
       CommonPropertyHandlers.Height(),
       CommonPropertyHandlers.Color(),
+      TextShapePropertyHandlers.TextContent(),
+      TextShapePropertyHandlers.FontSize(),
+      TextShapePropertyHandlers.FontFamily(),
+      TextShapePropertyHandlers.Bold(),
+      TextShapePropertyHandlers.Italic(),
       CommonPropertyHandlers.ShadowAngle(),
       CommonPropertyHandlers.ShadowRadius(),
       CommonPropertyHandlers.ShadowBlur(),

--- a/src/entity/shape/TextShape.ts
+++ b/src/entity/shape/TextShape.ts
@@ -7,7 +7,6 @@ import {
 import { AbstractShape } from "./Shape";
 
 export class TextShape extends AbstractShape {
-  public isEditing: boolean = false;
   constructor(
     id: number,
     startX: number,
@@ -21,11 +20,12 @@ export class TextShape extends AbstractShape {
     super(id, startX, startY, endX, endY);
   }
   public fontColor: string = '#000000';
+  public isTyping: boolean = false;
 
   draw(ctx: CanvasRenderingContext2D | null): void {
     if (!ctx) throw new Error("context is null");
     ctx.save();
-    if (this.isEditing) return;
+    if (this.isTyping) return;
     this.setShadow(ctx);
 
     ctx.font = `${this.fontSize}px ${this.fontFamily}`;
@@ -73,5 +73,6 @@ export interface TextShapeProps {
   endY: number;
   fontSize: number;
   fontFamily: string;
+  fontColor: string;
   color: string;
 }

--- a/src/model/ShapeModel.ts
+++ b/src/model/ShapeModel.ts
@@ -160,8 +160,8 @@ export class ShapeModel extends Observable<any> {
     const shape = this.shapes.find((shape) => shape.id === shapeId);
     if (shape) {
       shape.setProperties(propertyName, value);
-      if (shape instanceof TextShape) {
-        shape.isEditing = false;
+      if ("isTyping" in shape) {
+        shape.isTyping = false;
       }
       this.notifyShapesUpdated(shape);
       return shape;
@@ -250,10 +250,8 @@ export class ShapeModel extends Observable<any> {
     if (this.selectedShapes.length !== 1) {
       throw new Error("Only one shape can be selected.");
     }
-    // 일단은 TextShape에 대한 기능부터 구현하자 싶어서 if문 만들었습니다! 추후 제거 예정
-    if (!(shape instanceof TextShape))
-      throw new Error("Requested shape is not a TextShape.");
-    shape.isEditing = true;
+    if (!("isTyping" in shape)) throw new Error("Requested shape does not support text editing");
+    shape.isTyping = true;
     return {
       id: shape.id,
       textContent: shape.textContent,
@@ -263,6 +261,7 @@ export class ShapeModel extends Observable<any> {
       endY: shape.endY,
       fontSize: shape.fontSize,
       fontFamily: shape.fontFamily,
+      fontColor: shape.fontColor,
       color: shape.color,
     };
   }

--- a/src/view/Canvas.tsx
+++ b/src/view/Canvas.tsx
@@ -108,7 +108,7 @@ const Canvas: React.FC<{ viewModel: CanvasViewModel }> = ({ viewModel }) => {
             height: Math.abs(textInput.endY - textInput.startY),
             fontSize: textInput.fontSize,
             fontFamily: textInput.fontFamily,
-            color: textInput.color,
+            color: textInput.fontColor,
             lineHeight: `${Math.abs(textInput.endY - textInput.startY)}px`,
             resize: "none",
           }}

--- a/src/view/PropertyWindow.css
+++ b/src/view/PropertyWindow.css
@@ -89,6 +89,33 @@
   text-align: right;
 }
 
+.propertyItem button.active {
+  background: #333;
+  color: #fff;
+}
+
+.propertyGroup {
+  margin-bottom: 18px;
+  padding: 12px 0 8px 0;
+  background: transparent;
+}
+
+.groupTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: #4a5a6a;
+  margin-bottom: 8px;
+  letter-spacing: 0.5px;
+  padding-left: 2px;
+}
+
+.group-font .font-style-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+  margin-bottom: 8px;
+}
+
 .emptyText {
   color: #b0b8c1;
   font-size: 15px;

--- a/src/view/PropertyWindow.tsx
+++ b/src/view/PropertyWindow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./PropertyWindow.css";
 import { PropertyRendererFactory } from "../components/propertyRenderFactory";
 import { CommandManager } from "../command/CommandManager";
@@ -23,16 +23,19 @@ const PropertyWindow: React.FC<{ viewModel: PropertyWindowViewModel }> = ({
     (data: { selectedShapes: Shape[] }) => {
       setSelectedShapes(data.selectedShapes);
       setVersion((prevVersion) => prevVersion + 1);
-      if (selectedShapes.length === 1) {
-        const properties = selectedShapes[0].getProperties();
-        const newPropertyValues: Record<string, any> = {};
-        properties.forEach((property) => {
-          newPropertyValues[property.name] = property.value;
-        });
-        setPropertyValues(newPropertyValues);
-      }
     }
   );
+
+  useEffect(() => {
+    if (selectedShapes.length === 1) {
+      const properties = selectedShapes[0].getProperties();
+      const newPropertyValues: Record<string, any> = {};
+      properties.forEach((property) => {
+        newPropertyValues[property.name] = property.value;
+      });
+      setPropertyValues(newPropertyValues);
+    }
+  }, [selectedShapes, version]);
 
   if (selectedShapes.length === 0) {
     return (

--- a/src/view/PropertyWindow.tsx
+++ b/src/view/PropertyWindow.tsx
@@ -54,24 +54,23 @@ const PropertyWindow: React.FC<{ viewModel: PropertyWindowViewModel }> = ({
           <strong>{selectedShapes[0].constructor.name}</strong>
         </div>
         <div className="property">
-          {selectedShapes[0].getProperties().map((property) => {
-            return PropertyRendererFactory.createRenderer(
-              property.type,
-              property.name,
-              propertyValues[property.name] ?? property.value,
-              (newValue) => {
-                setPropertyValues((prevValues) => ({
-                  ...prevValues,
-                  [property.name]: newValue,
-                }));
-                commandManager.execute(CommandType.SET_PROPERTY, {
-                  shapeId: selectedShapes[0].id,
-                  propertyName: property.name,
-                  value: newValue,
-                });
-              }
-            );
-          })}
+          {PropertyRendererFactory.renderGroupedProperties(
+            selectedShapes[0].getProperties().map((property) => ({
+              ...property,
+              value: propertyValues[property.name] ?? property.value,
+            })),
+            (name, newValue) => {
+              setPropertyValues((prevValues) => ({
+                ...prevValues,
+                [name]: newValue,
+              }));
+              commandManager.execute(CommandType.SET_PROPERTY, {
+                shapeId: selectedShapes[0].id,
+                propertyName: name,
+                value: newValue,
+              });
+            }
+          )}
         </div>
         <div className="zorder-controls">
           <button

--- a/src/view/Toolbar.tsx
+++ b/src/view/Toolbar.tsx
@@ -127,8 +127,7 @@ const Toolbar: React.FC<{ viewModel: ToolbarViewModel }> = ({ viewModel }) => {
             },
           });
           commandManager.execute(CommandType.SET_STATE, {
-            stateType: "DrawState",
-            shapeType: "text",
+            stateType: "SelectState",
           });
         }}
       >

--- a/src/viewModel/canvasState/EditTextState.ts
+++ b/src/viewModel/canvasState/EditTextState.ts
@@ -23,7 +23,7 @@ export class EditTextState implements ICanvasState {
     if (this.editingShapeId !== null) {
       const changedShape = this.shapeModel.setProperty(
         this.editingShapeId,
-        PROPERTY_NAMES.TEXT_CONTENT,
+        PROPERTY_NAMES.FONT_CONTENT,
         newText
       );
       if ("isTyping" in changedShape) {

--- a/src/viewModel/canvasState/EditTextState.ts
+++ b/src/viewModel/canvasState/EditTextState.ts
@@ -1,5 +1,4 @@
 import { CanvasStateType, PROPERTY_NAMES } from "../../constants";
-import { TextShape } from "../../entity/shape";
 import { ShapeModel } from "../../model/ShapeModel";
 import { CanvasViewModel } from "../CanvasViewModel";
 import { ICanvasState } from "./CanvasState";
@@ -10,9 +9,9 @@ export class EditTextState implements ICanvasState {
 
   constructor(private viewModel: CanvasViewModel) {
     const shape = this.viewModel.getSelectedShapes()[0];
-    if (shape instanceof TextShape) {
+    if (shape && "isTyping" in shape) {
       this.editingShapeId = shape.id;
-      shape.isEditing = true;
+      shape.isTyping = true;
       const props = this.shapeModel.getTextShapeProperties();
       this.viewModel.notifyShowTextInput({
         ...props,
@@ -27,8 +26,8 @@ export class EditTextState implements ICanvasState {
         PROPERTY_NAMES.TEXT_CONTENT,
         newText
       );
-      if (changedShape instanceof TextShape) {
-        changedShape.isEditing = false;
+      if ("isTyping" in changedShape) {
+        changedShape.isTyping = false;
       }
       this.editingShapeId = null;
     }


### PR DESCRIPTION
## Line을 제외한 모든 도형에서 텍스트 입력 및 편집 지원
- `Shape` 인터페이스 및 `AbstractShape`에 공통 텍스트 속성 선언
- 더블클릭 시 텍스트 입력창 노출, 저장 시 속성 반영

## 텍스트 스타일(Bold/Italic) 추가
- boolean 타입으로 관리

## 속성창에서 텍스트 관련 속성 동적 노출
- textContent가 있을 때만 폰트/스타일 속성 노출
- Bold/Italic은 "B", "I" 버튼으로 표시

## 관련 스타일 및 렌더러 개선 및 그룹화
- 관련 있는 항목끼리 묶어서 보여주도록 속성 그룹화했습니다

## 개선할 점
- B, I 버튼 한줄에 보이도록
- text shape 더블클릭으로 입력 시 기존 text가 남아있는 오류
- Line 제외 모든 도형이라 텍스트 관련 속성을 그냥 interface에 넣고 isTyping 변수가 있냐 없냐에 따라 구분하도록 했는데... 좀 더 나은 방향이 있을지도... << 사실 각각에 다 fontFamily 이런식으로 넣어주고 if문으로 찾고 이런 과정이 좀 더러워질거라 생각했음 ㅜ 